### PR TITLE
Clang Build Configuration

### DIFF
--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -122,23 +122,44 @@ if(NOT ${PYTHON_VERSION_MAJOR} EQUAL "2")
 endif()
 set_property(GLOBAL PROPERTY PYTHON_INTERP_EXE ${PYTHON_EXECUTABLE})
 
-# @todo this needs place in a more appropriate location.
-if(DYNAMIC_LOAD_ENABLED)
-	set(CMAKE_CXX_FLAGS "-Wall -Wempty-body -Wignored-qualifiers -Wsign-compare -Wtype-limits -Wuninitialized -O3")
-else()
-	set(CMAKE_CXX_FLAGS "-Wall -Wempty-body -Wignored-qualifiers -Wsign-compare -Wtype-limits -Wuninitialized -O3 -DNO_DLLOAD")
+
+# Adding global configuration for the load DLL macro.
+if(NOT ${DYNAMIC_LOAD_ENABLED})
+    add_definitions(-DNO_DLLOAD)
 endif()
 
 # Adding compiler configuration for GCC.
 # The default configuration is to compile in DEBUG mode. These flags can be directly
 # overridden by setting the property of a target you wish to change them for.
 if(${CMAKE_COMPILER_IS_GNUCXX})
-
+    set(GCC_WARNINGS "-Wno-long-long -Wall -Wextra  -Wall -pedantic -Wempty-body -Wignored-qualifiers -Wsign-compare -Wtype-limits -Wuninitialized")
     # Adding global compiler definitions.
-    set(CMAKE_CXX_FLAGS_RELEASE "-Wall -O3 -DNDEBUG")
-    set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -O0 -DDEBUG --coverage -fprofile-arcs -DNO_DLLOAD")
+    set(CMAKE_CXX_FLAGS_RELEASE "-fPIC -O3 -DNDEBUG ${GCC_WARNINGS}")
+    set(CMAKE_CXX_FLAGS "-fPIC -O3 -g -DDEBUG --coverage -fprofile-arcs ${GCC_WARNINGS}")
+
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    # Configuring the Clang compiler
+    set(CLANG_WARNINGS "-Wno-long-long -Wall -Wextra -Wpadded -Wshorten-64-to-32")
+    set(CMAKE_CXX_FLAGS_RELEASE "-fPIC -O3 -DNDEBUG ${CLANG_WARNINGS}")
+    set(CMAKE_CXX_FLAGS "-fPIC -O3 -g -DDEBUG -fprofile-arcs ${CLANG_WARNINGS}")
     
-    # This allows for compilation of a re-locatable execuatable on GCC I need to be sure that I
-    # can make this portable to compilers other than GCC.
-    add_definitions(-fPIC)
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+    message(FATAL_ERROR "Configuration Not Implemented: ${CMAKE_CXX_COMPILER_ID}. Build not configured for selected compiler.")
+    
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    message(FATAL_ERROR "Configuration Not Implemented: ${CMAKE_CXX_COMPILER_ID}. Build not configured for selected compiler.")
+    
+else()
+    message(FATAL_ERROR "Unknown compiler: ${CMAKE_CXX_COMPILER_ID}. Build not configured for selected compiler.")
 endif()
+
+
+# if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+#     message(STATUS "Compiler is clang.")
+# elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+#     message(STATUS "Compiler is GNU.")
+# elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+#     message(STATUS "Compiler is Intel.")
+# elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+#     message(STATUS "Compiler is MSVC.")
+# endif()


### PR DESCRIPTION
Added warnings and configuration to the compiler settings for the clang. I also added error messages for non-supported compilers and where compiler support is pending.
