### PR TITLE
Issue #709: Fix for issue709, crash of linq in foreach with block and if.  Looks lik...

### DIFF
--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -4586,26 +4586,44 @@ complete_expression[] { CompleteElement element(this); ENTRY_DEBUG } :
 ;
 
 // match a linq_expression completely
-linq_expression_complete[] { CompleteElement element(this); ENTRY_DEBUG } :
+linq_expression_complete[] { CompleteElement element(this); int count_paren = 0; ENTRY_DEBUG } :
         {
             // start a mode to end at right bracket with expressions inside
             startNewMode(MODE_TOP | MODE_EXPECT | MODE_EXPRESSION);
         }
-        (options { greedy = true; } :
+        (options {warnWhenFollowAmbig = false; } : { LA(1) != RPAREN || count_paren > 0 }?
 
-        // commas as in a list
-        comma |
 
-        // right parentheses, unless we are in a pair of parentheses in an expression
-        { !inTransparentMode(MODE_INTERNAL_END_PAREN) }? rparen[false] |
+            (linq_expression_complete_inner[count_paren]) => linq_expression_complete_inner[count_paren, true]
+            
+        )*
+;
 
-        // argument mode (as part of call)
-        { inMode(MODE_ARGUMENT) }? argument |
+linq_expression_complete_inner[int & count_paren, bool update = false] { CALL_TYPE type = NOCALL; bool isempty = false; int call_count = 0; ENTRY_DEBUG } :
 
-        // expression with right parentheses if a previous match is in one
-        { LA(1) != ASCENDING && LA(1) != DESCENDING && LA(1) != ON && LA(1) != BY && LA(1) != FROM && LA(1) != SELECT && LA(1) != LET && LA(1) != WHERE && LA(1) != ORDERBY && LA(1) != GROUP && LA(1) != JOIN && LA(1) != IN && LA(1) != EQUALS && LA(1) != INTO && (LA(1) != RPAREN || inTransparentMode(MODE_INTERNAL_END_PAREN)) }? expression_setup_linq |
+    // commas as in a list
+    comma |
 
-        COLON)*
+    // right parentheses, unless we are in a pair of parentheses in an expression
+    { LA(1) == LPAREN }? expression_setup_linq ({ update }? set_int[count_paren, count_paren + 1])? |
+
+    { LA(1) == RPAREN && inputState->guessing }? rparen ({ update }? set_int[count_paren, count_paren - 1])? |
+
+    { LA(1) == RPAREN && !inputState->guessing}? expression_setup_linq ({ update }? set_int[count_paren, count_paren - 1])? |
+
+    { perform_call_check(type, isempty, call_count, -1) && type == CALL }? 
+    ({ update }? set_int[count_paren, isempty ? count_paren : count_paren + 1])? expression_setup_linq |
+
+    // argument mode (as part of call)
+    { inMode(MODE_ARGUMENT) }? argument |
+
+    // expression with right parentheses if a previous match is in one
+    { LA(1) != ASCENDING && LA(1) != DESCENDING && LA(1) != ON && LA(1) != BY && LA(1) != FROM && LA(1) != SELECT 
+        && LA(1) != LET && LA(1) != WHERE && LA(1) != ORDERBY && LA(1) != GROUP && LA(1) != JOIN && LA(1) != IN 
+        && LA(1) != EQUALS && LA(1) != INTO && (LA(1) != RPAREN || inTransparentMode(MODE_INTERNAL_END_PAREN)) }? expression_setup_linq |
+
+    COLON
+
 ;
 
 // variable name in an expression.  Includes array names, but not function calls

--- a/test/suite/linq_cs.cs.xml
+++ b/test/suite/linq_cs.cs.xml
@@ -423,5 +423,13 @@
 <decl_stmt><decl><type><name>s</name></type> <name>descending</name> <init>= <expr>0</expr></init></decl>;</decl_stmt>
 </unit>
 
+<unit>
+<foreach>foreach (<init><decl><type><name>var</name></type> <name>application</name> <range>in <expr><linq><from>from <expr><name>app</name></expr> <in>in <expr><name>apps</name></expr></in></from>
+                            <where>where <expr><name><name>app</name>.<name>MonitoredId</name></name> &gt; 0</expr></where>
+                            <select>select <expr><name>app</name></expr></select></linq></expr></range></decl></init>)
+<block>{
+    <if>if <condition>(<expr>true</expr>)</condition><then><block>{ }</block></then></if>
+}</block></foreach>
+</unit>
 
 </unit>


### PR DESCRIPTION
...e linq_expression_complete was cosuming the ')'.  Rewrite the rule so counts parenthesis.  It uses a syntactic predicate now, will look into eliminating that syntactic predicate.

Tried eliminating syntactic with catch, but did not work.
