### PR TITLE
Consolidate content into srcmlExec macro

### DIFF
--- a/CMake/buildExec.cmake
+++ b/CMake/buildExec.cmake
@@ -31,7 +31,11 @@ macro(srcMLExec EXEC_NAME EXEC_FILE)
     add_executable(${EXEC_NAME} ${EXEC_FILE})
     target_link_libraries(${EXEC_NAME} ${ARGN})
     if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
-        set_target_properties(${EXEC_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+		set_target_properties(${EXEC_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+        add_custom_command(TARGET srcml POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${PROJECT_SOURCE_DIR}/deps/${BUILD_ARCH}/$<CONFIGURATION>/bin"
+        $<TARGET_FILE_DIR:srcml>)
     elseif(APPLE)
         set_target_properties(${EXEC_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin LINK_FLAGS "-exported_symbols_list ${CMAKE_SOURCE_DIR}/CMake/srcml_export_list")
     elseif(WIN32)

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -21,21 +21,9 @@
 file(GLOB SRCML_HEADERS *.hpp)
 file(GLOB SRCML_SOURCE *.cpp)
 list(REMOVE_ITEM SRCML_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/srcml.cpp)
-if(WIN32)
-    add_executable(srcml srcml.cpp ${SRCML_HEADERS} ${SRCML_SOURCE})
-    target_link_libraries(srcml  srcml_shared ${SRCML_LIBRARIES})
-    if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
-        set_target_properties(srcml PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-        add_custom_command(TARGET srcml POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-        "${PROJECT_SOURCE_DIR}/deps/${BUILD_ARCH}/$<CONFIGURATION>/bin"
-        $<TARGET_FILE_DIR:srcml>)
-    elseif(WIN32)
-        set_target_properties(srcml PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin LINK_FLAGS "-Wl,--allow-multiple-definition")
-    endif()
-else()
-    srcMLExec(srcml "srcml.cpp;${SRCML_HEADERS};${SRCML_SOURCE}" srcml_shared ${SRCML_LIBRARIES})
-endif()
+
+srcMLExec(srcml "srcml.cpp;${SRCML_HEADERS};${SRCML_SOURCE}" srcml_shared ${SRCML_LIBRARIES})
+
 if(APPLE)							     
     install(CODE "execute_process(COMMAND \"/usr/bin/strip\" \"-u\" \"-r\" \"${CMAKE_BINARY_DIR}/bin/srcml\")")
 elseif(NOT WIN32)


### PR DESCRIPTION
This pull request is a proposed fix to Issue #1550.
Duplicate content has been moved to srcmlExec macro for clarity.

Tested on windows, but needs verification on Linux and OSX