### PR TITLE
Fix incorrect position separator on manpage #1701

### DIFF
--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -148,7 +148,7 @@ ${TABS_FLAG}.
 `--${POSITION_FLAG_LONG}`
 : Insert attributes for the start (line and column) and end (line and column) of an element in the start tag. These attributes have a default prefix of
 "${SRCML_EXT_POSITION_NS_PREFIX_DEFAULT}" in the namespace
-"${SRCML_EXT_POSITION_NS_URL}", e.g., `<class pos:start="15,1" pos:end="25,2">`
+"${SRCML_EXT_POSITION_NS_URL}", e.g., `<class pos:start="15:1" pos:end="25:2">`
 
 `--${TABS_FLAG}`=<tabsize>
 : Set the tab size. Default is 8. Use of this option automatically


### PR DESCRIPTION
Corrects and closes #1701.

Changes are only to the manpage.