### PR TITLE
Treat empty file names as invalid arguments

### DIFF
--- a/src/libsrcml/libsrcml.cpp
+++ b/src/libsrcml/libsrcml.cpp
@@ -150,9 +150,13 @@ int srcml_version_number() {
  */
 int srcml(const char* input_filename, const char* output_filename) {
 
-    if (!input_filename || !output_filename) {
-
+    if (!input_filename || strcmp(input_filename, "") == 0) {
         global_archive.error_string = "No input file provided";
+        return SRCML_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (!output_filename || strcmp(output_filename, "") == 0) {
+        global_archive.error_string = "No output file provided";
         return SRCML_STATUS_INVALID_ARGUMENT;
     }
 

--- a/test/libsrcml/testsuite/test_srcml_convenience.cpp
+++ b/test/libsrcml/testsuite/test_srcml_convenience.cpp
@@ -164,6 +164,14 @@ int main(int, char* argv[]) {
     }
 
     {
+        dassert(srcml("", "foo.xml"), SRCML_STATUS_INVALID_ARGUMENT);
+    }
+
+    {
+        dassert(srcml("foo.c", ""), SRCML_STATUS_INVALID_ARGUMENT);
+    }
+
+    {
         dassert(srcml("foo.c", "foo.xml"), SRCML_STATUS_IO_ERROR);
     }
 


### PR DESCRIPTION
This a minor change that …

- reports empty file names as invalid arguments
- fixes the error message when the output file is invalid