### PR TITLE
Change PROJECT_SOURCE_DIR to PROJECT_BINARY_DIR for Windows build

### DIFF
--- a/package/nsis.cmake
+++ b/package/nsis.cmake
@@ -25,7 +25,7 @@ set(CPACK_NSIS_INSTALLED_ICON_NAME srcml_icon.ico)
 
 set(CPACK_NSIS_MODIFY_PATH ON)
 if(WIN32)
-    set(MSVC_REDIST ${PROJECT_SOURCE_DIR}/deps/tools/VC_redist.x64.exe)
+    set(MSVC_REDIST ${PROJECT_BINARY_DIR}/deps/tools/VC_redist.x64.exe)
     get_filename_component(vcredist_name "${MSVC_REDIST}" NAME)
     install(PROGRAMS ${MSVC_REDIST} DESTINATION bin)
     set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "ExecWait '\\\"$INSTDIR\\\\bin\\\\${vcredist_name}\\\" /passive /norestart'")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     message("MSVC BUILD")
 
     add_definitions(-DWITH_LIBXSLT)
-    set(WINDOWS_DEP_PATH ${PROJECT_SOURCE_DIR}/deps)
+    set(WINDOWS_DEP_PATH ${PROJECT_BINARY_DIR}/deps)
 
     include_directories(${WINDOWS_DEP_PATH}/include)
     link_directories(${WINDOWS_DEP_PATH}/$(ConfigurationName)/lib)

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -61,7 +61,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set_target_properties(srcml PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
     add_custom_command(TARGET srcml POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
-    "${PROJECT_SOURCE_DIR}/deps/$<CONFIGURATION>/bin"
+    "${PROJECT_BINARY_DIR}/deps/$<CONFIGURATION>/bin"
     $<TARGET_FILE_DIR:srcml>)
 elseif(APPLE)
     # Making the exported_symbols_list an empty file reduces size of executable, as strip does not work


### PR DESCRIPTION
Allows out-of-source Windows build