### PR TITLE
Fix output of cpp namespace for write-by-element api

### DIFF
--- a/src/libsrcml/srcml_translator.cpp
+++ b/src/libsrcml/srcml_translator.cpp
@@ -331,7 +331,10 @@ bool srcml_translator::add_start_element(const char* prefix, const char* name, c
     ++output_unit_depth;
 
     const char* used_uri = nullptr;
-    if (uri == nullptr || strcmp(SRCML_SRC_NS_URI, uri) != 0) {
+    if (uri == nullptr 
+        || (   strcmp(SRCML_SRC_NS_URI, uri)  != 0
+            && strcmp(SRCML_CPP_NS_URI, uri)  != 0
+            && strcmp(SRCML_DIFF_NS_URI, uri) != 0)) {
         used_uri = uri;
     }
 

--- a/src/libsrcml/srcml_translator.cpp
+++ b/src/libsrcml/srcml_translator.cpp
@@ -330,6 +330,7 @@ bool srcml_translator::add_start_element(const char* prefix, const char* name, c
 
     ++output_unit_depth;
 
+    // detect standard URIs and pass them on
     const char* used_uri = nullptr;
     if (uri == nullptr 
         || (   strcmp(SRCML_SRC_NS_URI, uri)  != 0

--- a/src/libsrcml/srcml_unit.cpp
+++ b/src/libsrcml/srcml_unit.cpp
@@ -1045,7 +1045,7 @@ int srcml_write_start_element(struct srcml_unit* unit, const char* prefix, const
     if (unit == nullptr || name == nullptr)
         return SRCML_STATUS_INVALID_ARGUMENT;
 
-
+    // set the found prefix, plus mark it as used
     if (uri && strcmp(SRCML_CPP_NS_URI, uri) == 0) {
 
         auto&& view = unit->namespaces->get<nstags::uri>();
@@ -1055,7 +1055,6 @@ int srcml_write_start_element(struct srcml_unit* unit, const char* prefix, const
         } else {
             unit->namespaces->push_back({ prefix, SRCML_CPP_NS_URI, NS_USED | NS_STANDARD });
         }
-
     }
 
     if (unit->unit_translator == nullptr || !unit->unit_translator->add_start_element(prefix, name, uri))

--- a/src/libsrcml/srcml_unit.cpp
+++ b/src/libsrcml/srcml_unit.cpp
@@ -1045,6 +1045,19 @@ int srcml_write_start_element(struct srcml_unit* unit, const char* prefix, const
     if (unit == nullptr || name == nullptr)
         return SRCML_STATUS_INVALID_ARGUMENT;
 
+
+    if (uri && strcmp(SRCML_CPP_NS_URI, uri) == 0) {
+
+        auto&& view = unit->namespaces->get<nstags::uri>();
+        auto it = view.find(SRCML_CPP_NS_URI);
+        if (it != view.end()) {
+            view.modify(it, [](Namespace& thisns){ thisns.flags |= NS_USED; });
+        } else {
+            unit->namespaces->push_back({ prefix, SRCML_CPP_NS_URI, NS_USED | NS_STANDARD });
+        }
+
+    }
+
     if (unit->unit_translator == nullptr || !unit->unit_translator->add_start_element(prefix, name, uri))
         return SRCML_STATUS_INVALID_INPUT;
 


### PR DESCRIPTION
With change cpp namespace is automatically added on when a cpp tag is used.  This is the behavior when using the internal output based on ANTLR tokens, but was not applied to write-by-element api.

This change carries that behavior to the write by element api.