### PR TITLE
Issue1743: Fix sticky cpp namespace

### DIFF
--- a/src/libsrcml/sax2_srcsax_handler.cpp
+++ b/src/libsrcml/sax2_srcsax_handler.cpp
@@ -438,6 +438,8 @@ void start_unit(void* ctx, const xmlChar* localname, const xmlChar* prefix, cons
     if (state == nullptr)
         return;
 
+    state->cpp_prefix = boost::optional<std::string>();
+
     // collect cpp prefix
     for (int i = 0; i < nb_namespaces; ++i) {
 


### PR DESCRIPTION
Solves issue #1743 by resetting cpp_prefix on start of each unit.