### PR TITLE
issue1867

### DIFF
--- a/test/client/testsuite/CMakeLists.txt
+++ b/test/client/testsuite/CMakeLists.txt
@@ -21,12 +21,12 @@
 
 # add client tests
 file(GLOB CLIENT_TESTS *.sh)
+list(REMOVE_ITEM CLIENT_TESTS "${CMAKE_CURRENT_SOURCE_DIR}/framework_test.sh")
+
 foreach(CLIENT_TEST ${CLIENT_TESTS})
     get_filename_component(TEST_NAME ${CLIENT_TEST} NAME)
 
-    if(NOT TEST_NAME STREQUAL "framework_test.sh")
-        add_test(NAME ${TEST_NAME} COMMAND ${CLIENT_TEST})
-        # Command line --timeout does NOT override this value
-        #set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 10) 
-    endif()
+    add_test(NAME ${TEST_NAME} COMMAND ${CLIENT_TEST})
+    # Command line --timeout does NOT override this value
+    #set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 10)
 endforeach()

--- a/test/client/testsuite/CMakeLists.txt
+++ b/test/client/testsuite/CMakeLists.txt
@@ -26,7 +26,7 @@ list(REMOVE_ITEM CLIENT_TESTS "${CMAKE_CURRENT_SOURCE_DIR}/framework_test.sh")
 foreach(CLIENT_TEST ${CLIENT_TESTS})
     get_filename_component(TEST_NAME ${CLIENT_TEST} NAME)
 
-    add_test(NAME ${TEST_NAME} COMMAND ${CLIENT_TEST})
+    add_test(NAME srcml.${TEST_NAME} COMMAND ${CLIENT_TEST})
     # Command line --timeout does NOT override this value
     #set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 10)
 endforeach()

--- a/test/libsrcml/testsuite/CMakeLists.txt
+++ b/test/libsrcml/testsuite/CMakeLists.txt
@@ -28,11 +28,11 @@ foreach(LIB_TEST ${LIB_TESTS})
     add_executable(${TEST_NAME} ${LIB_TEST})
     target_link_libraries(${TEST_NAME} ${LIBSRCML_LINK})
     set(TEST_DIR ${CMAKE_BINARY_DIR}/bin/tmp/${TEST_NAME})
-    add_test(NAME ${TEST_NAME} COMMAND $<TARGET_FILE:${TEST_NAME}>
+    add_test(NAME libsrcml.${TEST_NAME} COMMAND $<TARGET_FILE:${TEST_NAME}>
              WORKING_DIRECTORY ${TEST_DIR})
     file(MAKE_DIRECTORY ${TEST_DIR})
     set_target_properties(${TEST_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-    set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 15)
+    set_tests_properties(libsrcml.${TEST_NAME} PROPERTIES TIMEOUT 15)
 
     configure_file(copy.xsl ${TEST_DIR}/copy.xsl COPYONLY)
     configure_file(setlanguage.xsl ${TEST_DIR}/setlanguage.xsl COPYONLY)


### PR DESCRIPTION
- Refactor test case generation by replacing test with removing from list
- Add prefix of 'srcml.' to client test cases
- Add prefix of 'libsrcml.' to libsrcml unit test names
