### PR TITLE
issue1882

### DIFF
--- a/src/client/ParseQueue.hpp
+++ b/src/client/ParseQueue.hpp
@@ -51,7 +51,7 @@ public:
 
 private:
     ctpl::thread_pool pool;
-    WriteQueue* wqueue;
+    WriteQueue* wqueue = nullptr;
     int counter = 0;
     std::mutex e;
 };

--- a/src/libsrcml/srcml_archive.cpp
+++ b/src/libsrcml/srcml_archive.cpp
@@ -48,7 +48,7 @@ const char* srcml_archive_check_extension(const srcml_archive* archive, const ch
  */
 srcml_archive* srcml_archive_create() {
 
-    srcml_archive* archive;
+    srcml_archive* archive = nullptr;
     try {
 
         archive = new srcml_archive;

--- a/src/libsrcml/srcml_sax2_reader.hpp
+++ b/src/libsrcml/srcml_sax2_reader.hpp
@@ -33,10 +33,10 @@
 struct thread_args {
 
     /** control for sax processing */
-    srcSAXController* control;
+    srcSAXController* control = nullptr;
 
     /** handler with hooks for sax processing */
-    srcml_reader_handler* handler;
+    srcml_reader_handler* handler = nullptr;
 };
 
 /**

--- a/src/libsrcml/srcml_unit.cpp
+++ b/src/libsrcml/srcml_unit.cpp
@@ -546,15 +546,9 @@ int srcml_unit_parse_filename(struct srcml_unit* unit, const char* src_filename)
     if (unit == nullptr || src_filename == nullptr)
         return SRCML_STATUS_INVALID_ARGUMENT;
 
-    // open the file and use the file descriptor version
-    int src_fd = OPEN(src_filename, O_RDONLY, 0);
-    if (src_fd == -1) {
-        return SRCML_STATUS_IO_ERROR;
-    }
+    return srcml_unit_parse_internal(unit, src_filename, [src_filename](const char* encoding, bool output_hash, std::optional<std::string>& hash)-> UTF8CharBuffer* {
 
-    return srcml_unit_parse_internal(unit, src_filename, [src_fd](const char* encoding, bool output_hash, std::optional<std::string>& hash)-> UTF8CharBuffer* {
-
-        return new UTF8CharBuffer(src_fd, encoding, output_hash, hash);
+        return new UTF8CharBuffer(src_filename, encoding, output_hash, hash);
     });
 }
 

--- a/src/libsrcml/srcsax.hpp
+++ b/src/libsrcml/srcsax.hpp
@@ -33,7 +33,7 @@ public:
     bool is_archive;
 
     /** the xml documents encoding */
-    const char* encoding;
+    const char* encoding = nullptr;
 
     /* Internal context handling NOT FOR PUBLIC USE */
 

--- a/src/parser/UTF8CharBuffer.hpp
+++ b/src/parser/UTF8CharBuffer.hpp
@@ -53,13 +53,13 @@ typedef int (*srcml_close_callback)(void * context);
 struct srcMLIO {
 
     /** hold void * context */
-    void* context;
+    void* context = nullptr;
 
     /** provided read callback */
-    srcml_read_callback read_callback;
+    srcml_read_callback read_callback = nullptr;
 
     /** provided close callback */
-    srcml_close_callback close_callback;
+    srcml_close_callback close_callback = nullptr;
 };
 
 /**

--- a/test/libsrcml/testsuite/test_srcml_apply_transforms.cpp
+++ b/test/libsrcml/testsuite/test_srcml_apply_transforms.cpp
@@ -1511,6 +1511,7 @@ int main(int, char* argv[]) {
         fclose(f);
         fd = open("schema.rng", O_RDONLY, 0);
         srcml_append_transform_relaxng_fd(iarchive, fd);
+        close(fd);
         srcml_archive* oarchive = srcml_archive_clone(iarchive);
         srcml_archive_write_open_memory(oarchive, &s, &size);
 

--- a/test/libsrcml/testsuite/test_srcml_archive_read_open.cpp
+++ b/test/libsrcml/testsuite/test_srcml_archive_read_open.cpp
@@ -288,6 +288,7 @@ int main(int, char* argv[]) {
 
         srcml_archive_close(archive);
         srcml_archive_free(archive);
+        close(fd);
     }
 
     {
@@ -300,6 +301,7 @@ int main(int, char* argv[]) {
     {
         int fd = open("project_ns.xml", O_RDONLY, 0);
         dassert(srcml_archive_read_open_fd(0, fd), SRCML_STATUS_INVALID_ARGUMENT);
+        close(fd);
     }
 
     /*


### PR DESCRIPTION
- Fix missing close() for file descriptors
- Fix file descriptor leak and random crashes
- Initialize field pointers where declared
- Directly store file descriptor in void* context field instead of an object
