### PR TITLE
issue1892

### DIFF
--- a/src/client/src_output_filesystem.cpp
+++ b/src/client/src_output_filesystem.cpp
@@ -47,7 +47,7 @@ void src_output_filesystem(srcml_archive* srcml_arch, std::string_view output_di
 
         // unparse directly to the file
         // log before so error is on last shown filename
-        log << ++count << std::string_view(path.c_str());
+        log << ++count << path.string().c_str();
         int result = srcml_unit_unparse_filename(unit.get(), path.c_str());
         if (result != SRCML_STATUS_OK) {
            SRCMLstatus(ERROR_MSG, "Unable to extract file %s", path.c_str());

--- a/src/client/src_output_filesystem.cpp
+++ b/src/client/src_output_filesystem.cpp
@@ -47,7 +47,7 @@ void src_output_filesystem(srcml_archive* srcml_arch, std::string_view output_di
 
         // unparse directly to the file
         // log before so error is on last shown filename
-        log << ++count << path.c_str();
+        log << ++count << std::string_view(path.c_str());
         int result = srcml_unit_unparse_filename(unit.get(), path.c_str());
         if (result != SRCML_STATUS_OK) {
            SRCMLstatus(ERROR_MSG, "Unable to extract file %s", path.c_str());

--- a/src/client/src_output_filesystem.cpp
+++ b/src/client/src_output_filesystem.cpp
@@ -48,9 +48,9 @@ void src_output_filesystem(srcml_archive* srcml_arch, std::string_view output_di
         // unparse directly to the file
         // log before so error is on last shown filename
         log << ++count << path.string().c_str();
-        int result = srcml_unit_unparse_filename(unit.get(), path.c_str());
+        int result = srcml_unit_unparse_filename(unit.get(), path.string().c_str());
         if (result != SRCML_STATUS_OK) {
-           SRCMLstatus(ERROR_MSG, "Unable to extract file %s", path.c_str());
+           SRCMLstatus(ERROR_MSG, "Unable to extract file %s", path.string().c_str());
         }
     }
 }

--- a/src/client/srcml_write.cpp
+++ b/src/client/srcml_write.cpp
@@ -89,7 +89,7 @@ void srcml_write_request(std::shared_ptr<ParseRequest> prequest, TraceLog& log, 
         srcml_archive_enable_solitary_unit(output_archive);
         srcml_archive_disable_hash(output_archive);
 
-        srcml_archive_write_open_filename(output_archive, path.c_str());
+        srcml_archive_write_open_filename(output_archive, path.string().c_str());
     }
 
     // output scalar results

--- a/src/libsrcml/sax2_srcsax_handler.cpp
+++ b/src/libsrcml/sax2_srcsax_handler.cpp
@@ -261,24 +261,24 @@ void start_root(void* ctx, const xmlChar* localname, const xmlChar* prefix, cons
 
         // Convert to string_view
         std::vector<std::string_view> namespaceStrings(static_cast<std::size_t>(ns_length));
-        for (int i = 0; i < ns_length; ++i) {
+        for (std::size_t i = 0; i < static_cast<std::size_t>(ns_length); ++i) {
             namespaceStrings[i] = namespaces[i] ? (const char*) namespaces[i] : "";
         }
 
         std::size_t size = 0;
-        for (int i = 0; i < ns_length; i += 2) {
+        for (std::size_t i = 0; i < static_cast<std::size_t>(ns_length); i += 2) {
 
             // state->rootnsstr += "xmlns";
             size += 5;
             if (namespaces[i]) {
                 // state->rootnsstr += ":";
                 // state->rootnsstr += (const char*) namespaces[i];
-                size += 1 + namespaceStrings[static_cast<std::size_t>(i)].size();
+                size += 1 + namespaceStrings[i].size();
             }
             // state->rootnsstr += "=\"";
             // state->rootnsstr += (const char*) namespaces[i + 1];
             // state->rootnsstr += "\" ";
-            size += 2 + namespaceStrings[static_cast<std::size_t>(i) + 1].size() + 2;
+            size += 2 + namespaceStrings[i + 1].size() + 2;
         }
 
         state->rootnsstr.reserve(size);

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -28,10 +28,7 @@ FetchContent_Declare(antlrsrc
     PATCH_COMMAND patch -p 1 -i ${CMAKE_CURRENT_SOURCE_DIR}/antlr.patch
     USES_TERMINAL_PATCH ON
 )
-FetchContent_GetProperties(antlrsrc)
-if(NOT antlrsrc_POPULATED)
-    FetchContent_Populate(antlrsrc)
-endif()
+FetchContent_MakeAvailable(antlrsrc)
 
 # antlr library
 file(GLOB ANTLR_SOURCE ${antlrsrc_SOURCE_DIR}/lib/cpp/src/*.cpp)

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -23,10 +23,11 @@ find_package(Java COMPONENTS Runtime REQUIRED)
 
 # Setup ANTLR 2.7 library
 include(FetchContent)
+set(FETCHCONTENT_QUIET FALSE)
 FetchContent_Declare(antlrsrc
     URL https://www.antlr2.org/download/antlr-2.7.7.tar.gz
     PATCH_COMMAND patch -p 1 -i ${CMAKE_CURRENT_SOURCE_DIR}/antlr.patch
-    USES_TERMINAL_PATCH ON
+    URL_HASH MD5=01cc9a2a454dd33dcd8c856ec89af090
 )
 FetchContent_MakeAvailable(antlrsrc)
 

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -25,31 +25,11 @@ find_package(Java COMPONENTS Runtime REQUIRED)
 include(FetchContent)
 FetchContent_Declare(antlrsrc
     URL https://www.antlr2.org/download/antlr-2.7.7.tar.gz
+    PATCH_COMMAND patch -p 1 -i ${CMAKE_CURRENT_SOURCE_DIR}/antlr.patch
 )
 FetchContent_GetProperties(antlrsrc)
 if(NOT antlrsrc_POPULATED)
-    # Fetch the content using previously declared details
     FetchContent_Populate(antlrsrc)
-
-    if (NOT antlrsrc_PATCHED)
-        # Add needed include file for CharScanner.hpp
-        # Comment out use of std::binary_function, deprecated in C++11 and removed in C++17
-        set(CHARSCANNER_HPP "${antlrsrc_SOURCE_DIR}/lib/cpp/antlr/CharScanner.hpp")
-        file(READ ${CHARSCANNER_HPP} FILE_CONTENTS)
-        string(REPLACE "#include <antlr/config.hpp>\n\n" "#include <antlr/config.hpp>\n#include <string.h>\n\n" FILE_CONTENTS "${FILE_CONTENTS}")
-        string(REPLACE "class ANTLR_API CharScannerLiteralsLess : public ANTLR_USE_NAMESPACE(std)binary_function<ANTLR_USE_NAMESPACE(std)string,ANTLR_USE_NAMESPACE(std)string,bool>"
-                    "class ANTLR_API CharScannerLiteralsLess /* : public ANTLR_USE_NAMESPACE(std)binary_function<ANTLR_USE_NAMESPACE(std)string,ANTLR_USE_NAMESPACE(std)string,bool> */" FILE_CONTENTS "${FILE_CONTENTS}")
-        file(WRITE ${CHARSCANNER_HPP} "${FILE_CONTENTS}")
-
-        # Remove pragma warning disable that is no longer valid
-        set(CONFIG_HPP "${antlrsrc_SOURCE_DIR}/lib/cpp/antlr/config.hpp")
-        file(READ ${CONFIG_HPP} FILE_CONTENTS)
-        string(REPLACE "# pragma warning( disable : 4786 4231 )" "# pragma warning( disable : 4786 )" FILE_CONTENTS "${FILE_CONTENTS}")
-        file(WRITE ${CONFIG_HPP} "${FILE_CONTENTS}")
-
-        # Mark so that further patches are not performed
-        set(antlrsrc_PATCHED TRUE CACHE BOOL "Indicates that Antlr source was patched" FORCE)
-    endif()
 endif()
 
 # antlr library

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -172,6 +172,7 @@ if(NOT ENABLE_ANTLR_BUILD_WARNINGS)
     target_compile_options(antlr PRIVATE
         $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-format>
         $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-misleading-indentation>
+        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-deprecated-declarations>
         $<$<CXX_COMPILER_ID:MSVC>:/wd4365> # conversion from 'int' to 'unsigned int',
         $<$<CXX_COMPILER_ID:MSVC>:/wd4267> # 'return': conversion from 'size_t' to 'unsigned int', possible loss of data
         $<$<CXX_COMPILER_ID:MSVC>:/wd4244> # 'argument': conversion from 'unsigned int' to '_Elem', possible loss of data

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -26,6 +26,7 @@ include(FetchContent)
 FetchContent_Declare(antlrsrc
     URL https://www.antlr2.org/download/antlr-2.7.7.tar.gz
     PATCH_COMMAND patch -p 1 -i ${CMAKE_CURRENT_SOURCE_DIR}/antlr.patch
+    USES_TERMINAL_PATCH ON
 )
 FetchContent_GetProperties(antlrsrc)
 if(NOT antlrsrc_POPULATED)

--- a/src/parser/antlr.patch
+++ b/src/parser/antlr.patch
@@ -1,0 +1,32 @@
+diff -r -u a/lib/cpp/antlr/CharScanner.hpp b/lib/cpp/antlr/CharScanner.hpp
+--- b/lib/cpp/antlr/CharScanner.hpp
++++ b/lib/cpp/antlr/CharScanner.hpp
+@@ -9,6 +9,7 @@
+  */
+ 
+ #include <antlr/config.hpp>
++#include <string.h>
+ 
+ #include <map>
+ 
+@@ -64,7 +65,7 @@
+ 
+ /** Functor for the literals map
+  */
+-class ANTLR_API CharScannerLiteralsLess : public ANTLR_USE_NAMESPACE(std)binary_function<ANTLR_USE_NAMESPACE(std)string,ANTLR_USE_NAMESPACE(std)string,bool> {
++class ANTLR_API CharScannerLiteralsLess /* : public ANTLR_USE_NAMESPACE(std)binary_function<ANTLR_USE_NAMESPACE(std)string,ANTLR_USE_NAMESPACE(std)string,bool> */ {
+ private:
+ 	const CharScanner* scanner;
+ public:
+diff -r -u a/lib/cpp/antlr/config.hpp b/lib/cpp/antlr/config.hpp
+--- a/lib/cpp/antlr/config.hpp
++++ b/lib/cpp/antlr/config.hpp
+@@ -52,7 +52,7 @@
+ // This warning really gets on my nerves.
+ // It's the one about symbol longer than 256 chars, and it happens
+ // all the time with STL.
+-# pragma warning( disable : 4786 4231 )
++# pragma warning( disable : 4786 )
+ // this shuts up some DLL interface warnings for STL
+ # pragma warning( disable : 4251 )
+ 

--- a/src/parser/antlr.patch
+++ b/src/parser/antlr.patch
@@ -1,3 +1,6 @@
+# Add needed include file for CharScanner.hpp
+# Comment out use of std::binary_function, deprecated in C++11 and removed in C++17 in CharScanner.hpp
+# Remove pragma warning disable that is no longer valid in config.hpp
 diff -r -u a/lib/cpp/antlr/CharScanner.hpp b/lib/cpp/antlr/CharScanner.hpp
 --- b/lib/cpp/antlr/CharScanner.hpp
 +++ b/lib/cpp/antlr/CharScanner.hpp


### PR DESCRIPTION
- Add patch file
- Disable -Wdeprecated-declarations of antlr source
- Replace explicit patch handling with patch file
- Add the patch comments to the patch file
- Replace explicit FetchContent calls with FetchContent_MakeAvailable() as specialization is no longer needed
- Add HASH for antlr download
- Fix MSVC warnings and errors
- Another attempt to fix MSVC with std::filesystem::path::c_str()
- Another attempt to fix MSVC with std::filesystem::path::c_str()
