### PR TITLE
Fix build on develop branch for macOS and Ubuntu

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -29,7 +29,7 @@ To generate a makefile in your build directory:
 
 The main packages required may be installed via brew:
 
-    brew install antlr2 boost cmake
+    brew install antlr2 boost libxslt cmake
 
 Libarchive greater than 3.0.0 is required. For macOS previous to Catalina (19.*.*), libarchive.a 3.3.* must be 
 statically included. Use brew to install a more recent version:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_INSTALL_SYSTEM_RUNTIME_COMPONENT SRCML)
 include(InstallRequiredSystemLibraries)
 
+# For nixes, set -fPIC compil flag
+if (UNIX AND NOT APPLE)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
+
 # Build options
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(BUILD_LIBSRCML "Build (and potentially install) libsrcml" ON)

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 
 find_package(LibArchive 3 REQUIRED)
 find_package(CURL REQUIRED)
+find_package(Threads REQUIRED)
 
 # rpath needs help on macos
 if(APPLE)
@@ -54,7 +55,7 @@ target_include_directories(ctpl_stl SYSTEM INTERFACE ${ctpl_stl_SOURCE_DIR})
 file(GLOB CLIENT_SOURCE *.hpp *.cpp)
 add_executable(srcml ${CLIENT_SOURCE})
 target_include_directories(srcml BEFORE PRIVATE .)
-target_link_libraries(srcml PRIVATE srcML::LibsrcML LibArchive::LibArchive CURL::libcurl cli11 ctpl_stl)
+target_link_libraries(srcml PRIVATE srcML::LibsrcML LibArchive::LibArchive CURL::libcurl Threads::Threads cli11 ctpl_stl)
 
 # Put executable in bin directory
 set_target_properties(srcml PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/src/libsrcml/CMakeLists.txt
+++ b/src/libsrcml/CMakeLists.txt
@@ -6,6 +6,13 @@
 #
 # CMake files for the library libsrcml
 
+if(APPLE)
+    # Apple specific issue: libxslt provided by macOS is *broken*, we need to replace it by homebrew version
+    #     brew install libxslt
+    # And then tell pkg_config to prefer homebrew's version
+    set( ENV{PKG_CONFIG_PATH} "/opt/homebrew/opt/libxslt/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}" )
+endif()
+
 find_package(LibXml2 REQUIRED)
 find_package(LibXslt REQUIRED)
 find_package(Iconv REQUIRED)


### PR DESCRIPTION
Hello @mlcollard 

I hope you will have time to study the following PR which solves quite tricky build issues which I encountered recently:

* on macOS: the default version of `libxlst` is broken, we need to replace it by homebrew's version:

The default version of libxslt provided by apple at `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/lib/libxslt.tbd` is actually broken and leads to difficult to diagnose compilation errors with macOX SDK 14.

See detail at https://github.com/srcML/srcML/commit/6c154398a1c7d6a2ec89e13d0a1f3ac1e4aa7900

* on Ubuntu: fixed issues with "-fPIC" and "-pthread"

I hope those will get merged, or partially merged!

----

PS: 
I'm a recurrent user of srcML, which is greatly helping me in my work. Many thanks to you!

I used it to create an automatic binding generator (from C++ to python, using pybind11). It is quite successful, and it is the driving force behind an open source project which I released (https://github.com/pthom/imgui_bundle)

I plan to release this generator in the next weeks, and I will try to contact you by email about it. You might be interested!
 