### PR TITLE
Add ANTLR compile options to hide warnings on macOS

### DIFF
--- a/presets/CMakeMacOSPresets.json
+++ b/presets/CMakeMacOSPresets.json
@@ -20,6 +20,7 @@
       "cacheVariables": {
         // Making the exported_symbols_list an empty file reduces size of executable, as strip does not work
         "SRCML_CLIENT_LINK_FLAGS": "-exported_symbols_list /dev/null",
+        "SRCML_ANTLR_COMPILE_FLAGS": "-Wno-system-headers;-Wno-deprecated-declarations;-Wno-format",
         "CMAKE_BUILD_TYPE": "Release",
         // Build for both x86 and arm64
         "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -59,6 +59,7 @@ file(GLOB ANTLR_SOURCE ${antlrsrc_SOURCE_DIR}/lib/cpp/src/*.cpp)
 list(REMOVE_ITEM ANTLR_SOURCE "${antlrsrc_SOURCE_DIR}/lib/cpp/src/dll.cpp")
 target_sources(antlr PRIVATE "${ANTLR_SOURCE}")
 target_include_directories(antlr SYSTEM PUBLIC "${antlrsrc_SOURCE_DIR}/lib/cpp/" SYSTEM PRIVATE "${antlrsrc_SOURCE_DIR}/lib/cpp/")
+target_compile_options(antlr PRIVATE ${SRCML_ANTLR_COMPILE_FLAGS})
 
 # Generated source from antlr and the parser
 set(CMAKE_GENERATED_SOURCE_DIR ${CMAKE_BINARY_DIR}/parser)


### PR DESCRIPTION
#2023