### PR TITLE
[Old] Fix infinite loop with certain C# @-strings

### DIFF
--- a/src/parser/CommentTextLexer.g
+++ b/src/parser/CommentTextLexer.g
@@ -169,7 +169,7 @@ COMMENT_TEXT {
 
     '\042' /* '\"' */
         { dquote_count = 1; }
-        (options { greedy = true; } : { prevLA != '\\' }? '\042' { ++dquote_count; })*
+        (options { greedy = true; } : { prevLA != '\\' || noescape }? '\042' { ++dquote_count; })*
     {
         if ((noescape && (dquote_count % 2 == 1)) ||
             (!noescape && (prevLA != '\\') && (mode == STRING_END))) {

--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -4997,21 +4997,13 @@ variable_identifier_array_grammar_sub[bool& iscomplex] { CompleteElement element
 
   Handles the contents of a variables array index.
 */
-variable_identifier_array_grammar_sub_contents {
-        bool found_expr = false;
-        bool is_expr = false;
-        int prev_look_ahead = LA(1);
-        int num_loops = 0;
-        int max_loops = 50;
-
-        ENTRY_DEBUG
-} :
+variable_identifier_array_grammar_sub_contents { bool found_expr = false; bool is_expr = false; ENTRY_DEBUG } :
         { !inLanguage(LANGUAGE_CSHARP) && !inLanguage(LANGUAGE_OBJECTIVE_C) }?
         complete_expression |
 
         { inLanguage(LANGUAGE_CSHARP) || inLanguage(LANGUAGE_OBJECTIVE_C) }?
         (options { greedy = true; } :
-            { LA(1) != RBRACKET && num_loops < max_loops }?
+            { LA(1) != RBRACKET }?
             (
                 { LA(1) == COMMA /* stop warning */ }?
                 {
@@ -5027,10 +5019,6 @@ variable_identifier_array_grammar_sub_contents {
                 complete_expression
                 {
                     found_expr = true;
-
-                    if (prev_look_ahead == LA(1)) {
-                        num_loops += 1;
-                    }
                 }
             )
 

--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -4992,21 +4992,56 @@ variable_identifier_array_grammar_sub[bool& iscomplex] { CompleteElement element
         RBRACKET
 ;
 
-// contents of array index
-variable_identifier_array_grammar_sub_contents{ bool found_expr = false; bool is_expr = false; ENTRY_DEBUG } :
-        { !inLanguage(LANGUAGE_CSHARP) && !inLanguage(LANGUAGE_OBJECTIVE_C) }? complete_expression |
+/*
+  variable_identifier_array_grammar_sub_contents
+
+  Handles the contents of a variables array index.
+*/
+variable_identifier_array_grammar_sub_contents {
+        bool found_expr = false;
+        bool is_expr = false;
+        int prev_look_ahead = LA(1);
+        int num_loops = 0;
+        int max_loops = 50;
+
+        ENTRY_DEBUG
+} :
+        { !inLanguage(LANGUAGE_CSHARP) && !inLanguage(LANGUAGE_OBJECTIVE_C) }?
+        complete_expression |
 
         { inLanguage(LANGUAGE_CSHARP) || inLanguage(LANGUAGE_OBJECTIVE_C) }?
-            (options { greedy = true; } : { LA(1) != RBRACKET }?
-                ({ /* stop warning */ LA(1) == COMMA }? { if (!found_expr) { empty_element(SEXPRESSION, true); }
+        (options { greedy = true; } :
+            { LA(1) != RBRACKET && num_loops < max_loops }?
+            (
+                { LA(1) == COMMA /* stop warning */ }?
+                {
+                    if (!found_expr) {
+                        empty_element(SEXPRESSION, true);
+                    }
+                }
+                COMMA
+                {
+                    found_expr = false;
+                } |
 
+                complete_expression
+                {
+                    found_expr = true;
 
-                 } COMMA { found_expr = false; } | complete_expression { found_expr = true; })
+                    if (prev_look_ahead == LA(1)) {
+                        num_loops += 1;
+                    }
+                }
+            )
 
-                set_bool[is_expr, true]
-
+            set_bool[is_expr, true]
         )*
-        { if (is_expr && !found_expr) empty_element(SEXPRESSION, true); }
+
+        {
+            if (is_expr && !found_expr) {
+                empty_element(SEXPRESSION, true);
+            }
+        }
 ;
 
 // handle C# attribute

--- a/test/parser/testsuite/string_cs.cs.xml
+++ b/test/parser/testsuite/string_cs.cs.xml
@@ -35,4 +35,20 @@ two
 three"</literal></expr>;</expr_stmt>
 </unit>
 
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C#">
+<expr_stmt><expr><literal type="string">@"\""\"")"</literal></expr>;</expr_stmt> <expr_stmt><expr><literal type="string">@"[@\"</literal></expr>;</expr_stmt>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C#">
+<expr_stmt><expr><literal type="string">@"\""\"")"</literal></expr>;</expr_stmt> <expr_stmt><expr><literal type="string">@"[]@\"</literal></expr>;</expr_stmt>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C#">
+<expr_stmt><expr><literal type="string">@"""""@\"</literal></expr>;</expr_stmt>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C#">
+<expr_stmt><expr><literal type="string">@""""</literal><literal type="string">@""""</literal></expr>;</expr_stmt>
+</unit>
+
 </unit>


### PR DESCRIPTION
### What causes this infinite loop?

The pair of C# at-strings `@"\""\"")"; @"[@\";` will cause an infinite loop in srcML. Example:

```
srcml --text='@"\""\"")"; @"[@\";' --language="C#"
```

### Short Description

This fix introduces a loop counter in `srcMLParser.g`'s `variable_identifier_array_grammar_sub_contents`. If the previous LA(1) value is the same as the current LA(1) value, the loop counter increments by 1. The maximum number of loops is set to 50, although it is rare for any other case to exceed 0. This sequence is only true in C# (or Objective C) and if LA(1) is _not_ a right bracket.

### Detailed Description

**Note:** `srcMLParser.cpp` is a _generated file_ made using `srcMLParser.g`. It is located in the `parser` directory wherever you built srcML. Changing anything in this file is not recommended; make changes in `srcMLParser.g` if needed.

1. `fillTokenBuffer()` reaches `srcMLParser::start()` in `StreamMLParser.hpp`. Everything after this occurs in `srcMLParser.cpp`.
2. `start()` reaches an else-if where LA(1) is a member of the 2nd token set. It then calls `statement_part()`. 
3. `statement_part()` reaches the final else statement, reaches the next final else statement, and hits a specific else-if where LA(1) is a member of the 21st token set and the mode is EXPRESSION. It then calls `expression_part_plus_linq()`.
4. `expression_part_plus_linq()` arrives at the else-if before the final else, where LA(1) is a member of the 21st token set. It then calls `expression_part()`.
5. `expression_part()` goes through many if/else-if/else statements before finally reaching the else-if just above the final else at the end of the function; this checks if LA(1) is `[` or is at `[`, which it is. It then calls `variable_identifier_array_grammar_sub()`.
6. `variable_identifier_array_grammar_sub()` hits the first if statement (where the input state's "guessing" is 0), hits the if statement where LA(1) is `[`, and then proceeds to `variable_identifier_array_grammar_sub_contents()`.
7. *\** `variable_identifier_array_grammar_sub_contents()` is where the infinite loop occurs: inside of the function's infinite for-loop (`for (;;)`). The first if statement inside the for-loop is always entered, followed by the else-if where LA(1) is a member of the 81st token set. `complete_expression()` also contains an infinite for-loop that is immediately entered and exited. The input state's "guessing" is still 0, so `found_expr` is true. **And now, the program is stuck.** To exit this infinite loop, the code needs to hit `goto _loop552;` in the final else.