### PR TITLE
Fix infinite loop with certain C# @-strings

### DIFF
--- a/src/parser/CommentTextLexer.g
+++ b/src/parser/CommentTextLexer.g
@@ -169,7 +169,7 @@ COMMENT_TEXT {
 
     '\042' /* '\"' */
         { dquote_count = 1; }
-        (options { greedy = true; } : { prevLA != '\\' }? '\042' { ++dquote_count; })*
+        (options { greedy = true; } : { prevLA != '\\' || noescape }? '\042' { ++dquote_count; })*
     {
         if ((noescape && (dquote_count % 2 == 1)) ||
             (!noescape && (prevLA != '\\') && (mode == STRING_END))) {

--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -4997,21 +4997,13 @@ variable_identifier_array_grammar_sub[bool& iscomplex] { CompleteElement element
 
   Handles the contents of a variables array index.
 */
-variable_identifier_array_grammar_sub_contents {
-        bool found_expr = false;
-        bool is_expr = false;
-        int prev_look_ahead = LA(1);
-        int num_loops = 0;
-        int max_loops = 50;
-
-        ENTRY_DEBUG
-} :
+variable_identifier_array_grammar_sub_contents { bool found_expr = false; bool is_expr = false; ENTRY_DEBUG } :
         { !inLanguage(LANGUAGE_CSHARP) && !inLanguage(LANGUAGE_OBJECTIVE_C) }?
         complete_expression |
 
         { inLanguage(LANGUAGE_CSHARP) || inLanguage(LANGUAGE_OBJECTIVE_C) }?
         (options { greedy = true; } :
-            { LA(1) != RBRACKET && num_loops < max_loops }?
+            { LA(1) != RBRACKET }?
             (
                 { LA(1) == COMMA /* stop warning */ }?
                 {
@@ -5027,10 +5019,6 @@ variable_identifier_array_grammar_sub_contents {
                 complete_expression
                 {
                     found_expr = true;
-
-                    if (prev_look_ahead == LA(1)) {
-                        num_loops += 1;
-                    }
                 }
             )
 

--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -4992,21 +4992,56 @@ variable_identifier_array_grammar_sub[bool& iscomplex] { CompleteElement element
         RBRACKET
 ;
 
-// contents of array index
-variable_identifier_array_grammar_sub_contents{ bool found_expr = false; bool is_expr = false; ENTRY_DEBUG } :
-        { !inLanguage(LANGUAGE_CSHARP) && !inLanguage(LANGUAGE_OBJECTIVE_C) }? complete_expression |
+/*
+  variable_identifier_array_grammar_sub_contents
+
+  Handles the contents of a variables array index.
+*/
+variable_identifier_array_grammar_sub_contents {
+        bool found_expr = false;
+        bool is_expr = false;
+        int prev_look_ahead = LA(1);
+        int num_loops = 0;
+        int max_loops = 50;
+
+        ENTRY_DEBUG
+} :
+        { !inLanguage(LANGUAGE_CSHARP) && !inLanguage(LANGUAGE_OBJECTIVE_C) }?
+        complete_expression |
 
         { inLanguage(LANGUAGE_CSHARP) || inLanguage(LANGUAGE_OBJECTIVE_C) }?
-            (options { greedy = true; } : { LA(1) != RBRACKET }?
-                ({ /* stop warning */ LA(1) == COMMA }? { if (!found_expr) { empty_element(SEXPRESSION, true); }
+        (options { greedy = true; } :
+            { LA(1) != RBRACKET && num_loops < max_loops }?
+            (
+                { LA(1) == COMMA /* stop warning */ }?
+                {
+                    if (!found_expr) {
+                        empty_element(SEXPRESSION, true);
+                    }
+                }
+                COMMA
+                {
+                    found_expr = false;
+                } |
 
+                complete_expression
+                {
+                    found_expr = true;
 
-                 } COMMA { found_expr = false; } | complete_expression { found_expr = true; })
+                    if (prev_look_ahead == LA(1)) {
+                        num_loops += 1;
+                    }
+                }
+            )
 
-                set_bool[is_expr, true]
-
+            set_bool[is_expr, true]
         )*
-        { if (is_expr && !found_expr) empty_element(SEXPRESSION, true); }
+
+        {
+            if (is_expr && !found_expr) {
+                empty_element(SEXPRESSION, true);
+            }
+        }
 ;
 
 // handle C# attribute

--- a/test/parser/testsuite/string_cs.cs.xml
+++ b/test/parser/testsuite/string_cs.cs.xml
@@ -35,4 +35,20 @@ two
 three"</literal></expr>;</expr_stmt>
 </unit>
 
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C#">
+<expr_stmt><expr><literal type="string">@"\""\"")"</literal></expr>;</expr_stmt> <expr_stmt><expr><literal type="string">@"[@\"</literal></expr>;</expr_stmt>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C#">
+<expr_stmt><expr><literal type="string">@"\""\"")"</literal></expr>;</expr_stmt> <expr_stmt><expr><literal type="string">@"[]@\"</literal></expr>;</expr_stmt>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C#">
+<expr_stmt><expr><literal type="string">@"""""@\"</literal></expr>;</expr_stmt>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C#">
+<expr_stmt><expr><literal type="string">@""""</literal><literal type="string">@""""</literal></expr>;</expr_stmt>
+</unit>
+
 </unit>


### PR DESCRIPTION
### What causes this infinite loop?

The pair of C# at-strings `@"\""\"")"; @"[@\";` will cause an infinite loop in srcML. These changes will fix it. Example:

```
srcml --text='@"\""\"")"; @"[@\";' --language="C#"
```

### Description

C# at-strings cannot be escaped in the traditional sense (using something like `\`, for example). `CommentTextLexer` uses the variable `noescape` to handle these cases; however, it did not handle 2 consecutive double quotes (e.g., `""`). In C# at-strings, a pair of double quotes represents a singular double quote (e.g., `"`). This fix, while fixing the infinite loop, also allows srcML to mark up these cases correctly, fully encapsulating the result in `<literal type="string>`.

### Note

This fix originally used a "rate limiter" in `variable_identifier_array_grammar_sub_contents` in `srcMLParser.g`. It checked if the previous look-ahead value was the same as the current value, and if it hit a maximum number of loops, it would escape. This approach is more complex and more prone to potential errors, so it was left out; however, there is a chance the idea could be useful in the future.