### PR TITLE
Issue2085

### DIFF
--- a/src/libsrcml/qli_extensions.cpp
+++ b/src/libsrcml/qli_extensions.cpp
@@ -264,7 +264,7 @@ void match_element(xmlXPathParserContext* ctxt, int nargs) {
 
         const auto itpair = tokens.insert(token.size() == tokenView.size() ? std::move(token) : std::string(tokenView));
 
-        const bool valid = table->is_element_in_bucket(bucket, table->size_of_variable_bucket(bucket), *(itpair.first), node_ptr);
+        const bool valid = table->is_element_in_bucket(bucket, *(itpair.first), node_ptr);
 
         isValid = isValid || valid;
     }

--- a/src/libsrcml/unification_table.cpp
+++ b/src/libsrcml/unification_table.cpp
@@ -92,7 +92,7 @@ bool UnificationTable::does_element_match_variable(std::string_view variable_ide
     return true;
 }
 
-bool UnificationTable::is_element_in_bucket(std::string_view variable_identifier, int order, std::string_view t, uintptr_t address) const {
+bool UnificationTable::is_element_in_bucket(std::string_view variable_identifier, std::string_view t, uintptr_t address) const {
     std::string token(t);
     const auto bucketVar = bucket.find(variable_identifier);
     for (int i = size_of_variable_bucket(variable_identifier); i > 0; --i) {

--- a/src/libsrcml/unification_table.hpp
+++ b/src/libsrcml/unification_table.hpp
@@ -43,7 +43,7 @@ public:
     void add_to_token_list(std::string_view, int, std::string_view, std::uintptr_t);
 
     bool does_element_match_variable(std::string_view, int, std::string_view first, uintptr_t second) const;
-    bool is_element_in_bucket(std::string_view, int, std::string_view first, uintptr_t second) const;
+    bool is_element_in_bucket(std::string_view, std::string_view first, uintptr_t second) const;
     bool regex_match_bucket(std::string_view, std::string);
 
     void empty_buckets();

--- a/src/libsrcml/xpath_generator.cpp
+++ b/src/libsrcml/xpath_generator.cpp
@@ -288,7 +288,7 @@ std::string XPathGenerator::convert() {
                     std::string attribute = build_expr.substr(0,word_selector_pos);
                     attribute = attribute.substr(attribute.find_first_not_of(" "),attribute.find_last_not_of(" ") - attribute.find_first_not_of(" ") + 1);
 
-                    std::string value = build_expr.substr(word_selector_pos+1,build_expr.size() - word_selector_pos);
+                    std::string value = build_expr.substr(word_selector_pos+2,build_expr.size() - word_selector_pos);
                     value = value.substr(value.find_first_not_of(" "),value.find_last_not_of(" ") - value.find_first_not_of(" ") + 1);
                     node = new XPathNode("contains(concat(' ', @"+attribute+", ' '), ' "+value+" ')");
                 }

--- a/src/libsrcml/xpath_generator.cpp
+++ b/src/libsrcml/xpath_generator.cpp
@@ -118,7 +118,6 @@ void number_add_calls(XPathNode* node, int group, std::map<std::string,int>* cou
     else if (node_text.find("qli:regex-match",0) != std::string::npos) {
         XPathNode* id_child = node->get_children()[0];
         std::string id_text = id_child->get_text();
-        int end_quote = node_text.find("\"",1);
         id_text.insert(id_text.size()-1,"_"+std::to_string(group));
         id_child->set_text(id_text);
     }

--- a/src/libsrcml/xpath_generator.cpp
+++ b/src/libsrcml/xpath_generator.cpp
@@ -280,8 +280,20 @@ std::string XPathGenerator::convert() {
             }
 
             else if (is_with_op) {
-                size_t attribute_pos = build_expr.find_first_of("=");
-                if (attribute_pos != std::string::npos) {
+                size_t word_selector_pos = build_expr.find("~=");
+                size_t attribute_pos = build_expr.find("=");
+
+                // ~= word selection
+                if (word_selector_pos != std::string::npos) {
+                    std::string attribute = build_expr.substr(0,word_selector_pos);
+                    attribute = attribute.substr(attribute.find_first_not_of(" "),attribute.find_last_not_of(" ") - attribute.find_first_not_of(" ") + 1);
+
+                    std::string value = build_expr.substr(word_selector_pos+1,build_expr.size() - word_selector_pos);
+                    value = value.substr(value.find_first_not_of(" "),value.find_last_not_of(" ") - value.find_first_not_of(" ") + 1);
+                    node = new XPathNode("contains(concat(' ', @"+attribute+", ' '), ' "+value+" ')");
+                }
+                // = attr matching
+                else if (attribute_pos != std::string::npos) {
                     std::string attribute = build_expr.substr(0,attribute_pos);
                     attribute = attribute.substr(attribute.find_first_not_of(" "),attribute.find_last_not_of(" ") - attribute.find_first_not_of(" ") + 1);
 
@@ -289,6 +301,7 @@ std::string XPathGenerator::convert() {
                     value = value.substr(value.find_first_not_of(" "),value.find_last_not_of(" ") - value.find_first_not_of(" ") + 1);
                     node = new XPathNode("@"+attribute+"=\""+value+"\"");
                 }
+                // broad attr selection
                 else {
                     build_expr = build_expr.substr(build_expr.find_first_not_of(" "),build_expr.find_last_not_of(" ") - build_expr.find_first_not_of(" ") + 1);
                     node = new XPathNode("@"+build_expr);

--- a/test/libsrcml/testsuite/test_srcql.cpp
+++ b/test/libsrcml/testsuite/test_srcql.cpp
@@ -9795,6 +9795,7 @@ if() a;
         R"(<block>{<block_content> <expr_stmt><expr><name>a</name></expr>;</expr_stmt> </block_content>}</block>)",
         R"(<block type="pseudo"><block_content> <expr_stmt><expr><name>a</name></expr>;</expr_stmt></block_content></block>)",
     };
+
     ////// WITH
     //FIND src:block WITH type
     {
@@ -9872,7 +9873,7 @@ if() a;
         srcml_archive_free(iarchive);
     }
 
-        const std::string literals_src = R"(
+    const std::string literals_src = R"(
 "Hello";
 'a';
 10;
@@ -10237,6 +10238,496 @@ nullptr;
         srcml_archive_close(iarchive);
         srcml_archive_free(iarchive);
     }
+
+
+    const std::string attributed_functions = R"(
+<unit xmlns="http://www.srcML.org/srcML/src" revision="1.0.0" language="C++" filename="untitled">
+<function name="a" type="int" stereotype="get"><type><name>int</name></type> <name>a</name><parameter_list>()</parameter_list> <block>{<block_content/>}</block></function>
+<function name="b" type="int" stereotype="set"><type><name>int</name></type> <name>b</name><parameter_list>()</parameter_list> <block>{<block_content/>}</block></function>
+<function name="c" type="int" stereotype="get set"><type><name>int</name></type> <name>c</name><parameter_list>()</parameter_list> <block>{<block_content/>}</block></function>
+<function name="d" type="bool" stereotype="set get"><type><name>bool</name></type> <name>d</name><parameter_list>()</parameter_list> <block>{<block_content/>}</block></function>
+<function name="e" type="bool" stereotype="property"><type><name>bool</name></type> <name>e</name><parameter_list>()</parameter_list> <block>{<block_content/>}</block></function>
+<function name="f" type="bool" stereotype="property property"><type><name>bool</name></type> <name>f</name><parameter_list>()</parameter_list> <block>{<block_content/>}</block></function>
+</unit>
+)";
+
+    const std::vector<std::string> attributed_functions_srcml {
+        R"(<function name="a" type="int" stereotype="get"><type><name>int</name></type> <name>a</name><parameter_list>()</parameter_list> <block>{<block_content/>}</block></function>)",
+        R"(<function name="b" type="int" stereotype="set"><type><name>int</name></type> <name>b</name><parameter_list>()</parameter_list> <block>{<block_content/>}</block></function>)",
+        R"(<function name="c" type="int" stereotype="get set"><type><name>int</name></type> <name>c</name><parameter_list>()</parameter_list> <block>{<block_content/>}</block></function>)",
+        R"(<function name="d" type="bool" stereotype="set get"><type><name>bool</name></type> <name>d</name><parameter_list>()</parameter_list> <block>{<block_content/>}</block></function>)",
+        R"(<function name="e" type="bool" stereotype="property"><type><name>bool</name></type> <name>e</name><parameter_list>()</parameter_list> <block>{<block_content/>}</block></function>)",
+        R"(<function name="f" type="bool" stereotype="property property"><type><name>bool</name></type> <name>f</name><parameter_list>()</parameter_list> <block>{<block_content/>}</block></function>)"
+    };
+
+    // FIND src:function WITH name
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH name"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 6);
+        for(int i = 0; i < 6; ++i) {
+            dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,i)), attributed_functions_srcml[i]);
+        }
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH type
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH name"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 6);
+        for(int i = 0; i < 6; ++i) {
+            dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,i)), attributed_functions_srcml[i]);
+        }
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH name = a
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH name = a"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 1);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[0]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH name = b
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH name = b"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 1);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[1]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH name = c
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH name = c"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 1);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[2]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH name = d
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH name = d"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 1);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[3]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH name = e
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH name = e"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 1);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[4]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH name = f
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH name = f"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 1);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[5]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH name = g
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH name = g"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_NONE);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH type = int
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH type = int"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 3);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[0]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,1)), attributed_functions_srcml[1]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,2)), attributed_functions_srcml[2]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH type = bool
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH type = bool"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 3);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[3]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,1)), attributed_functions_srcml[4]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,2)), attributed_functions_srcml[5]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype = get
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype = get"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 1);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[0]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype = set
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype = set"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 1);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[1]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype = get set
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype = get set"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 1);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[2]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype = set get
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype = set get"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 1);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[3]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype = property
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype = property"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 1);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[4]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype = property property
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype = property property"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 1);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[5]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype ~= get
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype ~= get"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 3);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[0]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,1)), attributed_functions_srcml[2]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,2)), attributed_functions_srcml[3]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype ~= set
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype ~= set"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 3);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[1]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,1)), attributed_functions_srcml[2]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,2)), attributed_functions_srcml[3]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype ~= property
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype ~= property"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 2);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[4]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,1)), attributed_functions_srcml[5]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype ~= get WITH stereotype ~= set
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype ~= get WITH stereotype ~= set"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 2);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[2]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,1)), attributed_functions_srcml[3]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype ~= set WITH stereotype ~= get
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype ~= set WITH stereotype ~= get"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 2);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[2]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,1)), attributed_functions_srcml[3]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype ~= property WITH stereotype ~= property
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype ~= property WITH stereotype ~= property"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 2);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), attributed_functions_srcml[4]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,1)), attributed_functions_srcml[5]);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:function WITH stereotype ~= property WITH stereotype ~= get
+    {
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,attributed_functions.c_str(),attributed_functions.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:function WITH stereotype ~= property WITH stereotype ~= get"), SRCML_STATUS_OK);
+
+        srcml_unit* unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_NONE);
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
 
     ////// OTHER
     //// Prefix Unification


### PR DESCRIPTION
These commits add word selection to the WITH operator. We follow CSS syntax, so `WITH attr` looks for the attribute, `WITH attr = value` directly matches the string value, and `WITH attr ~= value` looks for `value` as a word in `attr`.