### PR TITLE
Fix the five memory leaks in the XPath/srcQL transformations.

### DIFF
--- a/src/libsrcml/xpath_generator.cpp
+++ b/src/libsrcml/xpath_generator.cpp
@@ -771,6 +771,9 @@ std::string XPathGenerator::convert() {
 
     std::string xpath = source_exprs[0]->to_string();
 
+    // Free the xpath tree
+    delete source_exprs[0];
+
     return xpath;
 }
 


### PR DESCRIPTION
This merge fixes five memory leaks in the XPath/srcQL transformation implementation.

1) In `xpath_generator.cpp`, the final `XPathNode` which is slowly put together inside the `convert()` function is not freed at the end. I fixed this by calling `delete source_exprs[0];` before returning the string XPath.

2) In `xpathTransformation.cpp`'s `apply` function, we create a new `UnificationTable` which is vital for executing unification in srcQL queries. This is passed through to the various srcQL extension functions by attaching the table to the context's `userData` field. However, after execution, the tree is never fully freed. I have added a call to delete the tree after the execution is over.

3) In `xpathTransformation.cpp`'s `apply` function, we pass the srcQL query to the `srcql_convert_query_to_xpath` funciton in order to get back a `char*` containing the XPath to run. However, this `char*` is never freed. I added a call to delete the `char*` after it is compiled into an XPath.

4) In `xpathTransformation.cpp`'s `apply` function, we create a local variable `localCompiledXPath` to handle the fact that srcQL queries can produce different XPaths depending on the language context. However, this meant that when a srcQL query was compiled to an XPath, it wasn't freed, as it was never tied to the `compiled_xpath` member. I have added a local flag which goes true if the query is an XPath, and then frees `localCompiledXPath` if it is.

5) In `xpathTransformation.cpp` the destructor attempts to free `compiled_xpath`. However, the free is erroneously only done if `compiled_xpath` is null, as the if checks for `!compiled_xpath`. I have removed the `!` so the free functions as intended.

Note - I incorrectly said there were three errors fixed in the commit message, when in actuality there were five.