### PR TITLE
Remove commented-out CMake code with find_package(srcml

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -6,10 +6,6 @@
 #
 # CMake files for the srcML client
 
-# if(NOT srcML::LibsrcML)
-#     find_package(srcml REQUIRED)
-# endif()
-
 # Configure libarchive on macOS
 include(macos-libarchive.cmake)
 


### PR DESCRIPTION
Most of this is already in develop due to a pull request on another issue. However, there is still some commented-out CMake with the wrong symbol.