### PR TITLE
issue1679

### DIFF
--- a/src/libsrcml/srcml_translator.cpp
+++ b/src/libsrcml/srcml_translator.cpp
@@ -131,7 +131,7 @@ void srcml_translator::translate(UTF8CharBuffer* parser_input) {
         lexer.setTabsize((int)tabsize);
 
         // pure block comment lexer
-        CommentTextLexer textlexer(lexer.getInputState());
+        CommentTextLexer textlexer(lexer.getInputState(), getLanguage());
         textlexer.setSelector(&selector);
         textlexer.setTabsize((int)tabsize);
 

--- a/src/parser/CommentTextLexer.g
+++ b/src/parser/CommentTextLexer.g
@@ -32,6 +32,7 @@ header {
    #include <iostream>
    #include <antlr/TokenStreamSelector.hpp>
    #include <srcml_options.hpp>
+   #include <Language.hpp>
 }
 
 options {
@@ -43,6 +44,7 @@ options {
 class CommentTextLexer extends Lexer;
 
 options {
+    classHeaderSuffix="public Language";
     k = 1;
     noConstructors = true;
     defaultErrorHandler = false;
@@ -85,8 +87,8 @@ int dquote_count = 0;
 
 OPTION_TYPE options;
 
-CommentTextLexer(const antlr::LexerSharedInputState& state)
-    : antlr::CharScanner(state,true), mode(0), onpreprocline(false), noescape(false), delimiter1("")
+CommentTextLexer(const antlr::LexerSharedInputState& state, int language)
+    : Language(language), antlr::CharScanner(state,true), mode(0), onpreprocline(false), noescape(false), delimiter1("")
 {}
 
 private:

--- a/test/parser/testsuite/line_continuation_c.c.xml
+++ b/test/parser/testsuite/line_continuation_c.c.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<unit xmlns="http://www.srcML.org/srcML/src" revision="1.0.0">
+
+<unit revision="1.0.0" language="C">
+<comment type="line">//a\
+a;</comment>
+</unit>
+
+<unit revision="1.0.0" language="C">
+<comment type="line">//a</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="C">
+<comment type="line">//a\ </comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+</unit>

--- a/test/parser/testsuite/line_continuation_c.c.xml
+++ b/test/parser/testsuite/line_continuation_c.c.xml
@@ -16,4 +16,19 @@ a;</comment>
 <expr_stmt><expr><name>a</name></expr>;</expr_stmt>
 </unit>
 
+<unit revision="1.0.0" language="C">
+<comment type="line">//a\\</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="C">
+<comment type="line">//a\\\
+a;</comment>
+</unit>
+
+<unit revision="1.0.0" language="C">
+<comment type="line">//a\\\\</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
 </unit>

--- a/test/parser/testsuite/line_continuation_cpp.cpp.xml
+++ b/test/parser/testsuite/line_continuation_cpp.cpp.xml
@@ -16,4 +16,19 @@ a;</comment>
 <expr_stmt><expr><name>a</name></expr>;</expr_stmt>
 </unit>
 
+<unit revision="1.0.0" language="C++">
+<comment type="line">//a\\</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="C++">
+<comment type="line">//a\\\
+a;</comment>
+</unit>
+
+<unit revision="1.0.0" language="C++">
+<comment type="line">//a\\\\</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
 </unit>

--- a/test/parser/testsuite/line_continuation_cpp.cpp.xml
+++ b/test/parser/testsuite/line_continuation_cpp.cpp.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<unit xmlns="http://www.srcML.org/srcML/src" revision="1.0.0">
+
+<unit revision="1.0.0" language="C++">
+<comment type="line">//a\
+a;</comment>
+</unit>
+
+<unit revision="1.0.0" language="C++">
+<comment type="line">//a</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="C++">
+<comment type="line">//a\ </comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+</unit>

--- a/test/parser/testsuite/line_continuation_cs.cs.xml
+++ b/test/parser/testsuite/line_continuation_cs.cs.xml
@@ -16,4 +16,19 @@
 <expr_stmt><expr><name>a</name></expr>;</expr_stmt>
 </unit>
 
+<unit revision="1.0.0" language="C#">
+<comment type="line">//a\\</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="C#">
+<comment type="line">//a\\\</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="C#">
+<comment type="line">//a\\\\</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
 </unit>

--- a/test/parser/testsuite/line_continuation_cs.cs.xml
+++ b/test/parser/testsuite/line_continuation_cs.cs.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<unit xmlns="http://www.srcML.org/srcML/src" revision="1.0.0">
+
+<unit revision="1.0.0" language="C#">
+<comment type="line">//a\</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="C#">
+<comment type="line">//a</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="C#">
+<comment type="line">//a\ </comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+</unit>

--- a/test/parser/testsuite/line_continuation_java.java.xml
+++ b/test/parser/testsuite/line_continuation_java.java.xml
@@ -16,4 +16,19 @@
 <expr_stmt><expr><name>a</name></expr>;</expr_stmt>
 </unit>
 
+<unit revision="1.0.0" language="Java">
+<comment type="line">//a\\</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="Java">
+<comment type="line">//a\\\</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="Java">
+<comment type="line">//a\\\\</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
 </unit>

--- a/test/parser/testsuite/line_continuation_java.java.xml
+++ b/test/parser/testsuite/line_continuation_java.java.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<unit xmlns="http://www.srcML.org/srcML/src" revision="1.0.0">
+
+<unit revision="1.0.0" language="Java">
+<comment type="line">//a\</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="Java">
+<comment type="line">//a</comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="Java">
+<comment type="line">//a\ </comment>
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+</unit>
+
+</unit>


### PR DESCRIPTION
Implements the first part of #1679, the proper handling of line continuation in C and C++.

Does not handle the trigraphs.

- **Base CommentTextLexer on Language so it can use inLanguage()**
- **Add test cases for line continuations with comments**
- **Fix for line continuation at the end of a line comment**
- **Add tests for line continuation with escaped backslashes**
