### PR TITLE
issue2122

### DIFF
--- a/doc/manpage/CMakeLists.txt
+++ b/doc/manpage/CMakeLists.txt
@@ -131,14 +131,14 @@ set(NULL_SEPARATOR_SHORT "Z")
 configure_file(${CMAKE_SOURCE_DIR}/doc/manpage/srcml.cfg ${CMAKE_BINARY_DIR}/srcml.md)
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/srcml.1
     COMMAND ${PANDOC_EXE} -s -t man ${CMAKE_BINARY_DIR}/srcml.1.md --output ${CMAKE_BINARY_DIR}/srcml.1
-    COMMENT Generating ${CMAKE_BINARY_DIR}/srcml.1
+    COMMENT "Generating ${CMAKE_BINARY_DIR}/srcml.1"
     DEPENDS ${CMAKE_BINARY_DIR}/srcml.1.md
 )
 
 configure_file(${CMAKE_SOURCE_DIR}/doc/manpage/srcml.cfg ${CMAKE_BINARY_DIR}/srcml.1.md)
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/srcml.html 
     COMMAND ${PANDOC_EXE} -s -t html ${CMAKE_BINARY_DIR}/srcml.1.md --output ${CMAKE_BINARY_DIR}/srcml.html
-    COMMENT Generating ${CMAKE_BINARY_DIR}/srcml.html
+    COMMENT "Generating ${CMAKE_BINARY_DIR}/srcml.html"
     DEPENDS ${CMAKE_BINARY_DIR}/srcml.1.md
 )
 

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -146,13 +146,13 @@ a default tab size 8. Other tab sizes can be set using the option
 `--${TABS_FLAG}`.
 
 `--${POSITION_FLAG_LONG}`
-: Insert attributes for the start (line and column) and end (line and column) of an element in the start tag. These attributes have a default prefix of
+: Insert attributes for the start (line and column) and end (line and column) of an element in the start tag. Off by default. These attributes have a default prefix of
 "${SRCML_EXT_POSITION_NS_PREFIX_DEFAULT}" in the namespace
 "${SRCML_EXT_POSITION_NS_URL}", e.g., `<class pos:start="15,1" pos:end="25,2">`
 
 `--${TABS_FLAG}`=_tabsize_
 : Set the tab size. The default is 8. This option automatically
-turns on the position attributes.
+turns on the option `--${POSITION_FLAG_LONG}`.
 
 `--${EXPAND_TABS_FLAG}`
 : Expand tabs to spaces on input. Uses the default or option `--${TABS_FLAG}`

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -416,7 +416,7 @@ and Heather Michaud.
 
 ## COPYRIGHT
 
-Copyright (C) 2013-2023 srcML, LLC. (www.srcML.org)
+Copyright (C) 2013-2025 srcML, LLC. (www.srcML.org)
 
 The srcML Toolkit is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -63,8 +63,8 @@ in source-code format.
 `-${TEXT_FLAG_SHORT}` _text_, `--${TEXT_FLAG_LONG}`=_text_
 : Input the _text_ string as source code.
 Useful for short text input. Common escape sequences in C and echo are
-expanded, including \n, \t, \a, \b, \v, \e \xHH where H is 1 to 2 hex values,
-and \NNN and \0NNN where N is 1 to 3 octal digits.
+expanded, including ```\n```, ```\t```, ```\a```, ```\b```, ```\v```, ```\e```, ```\xHH``` where H is 1 to 2 hex values,
+and ```\NNN``` and ```\0NNN``` where N is 1 to 3 octal digits.
 
 `--${FILES_FROM_LONG}`=_file_
 : Treat the input _file_ as a list of source files.

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -50,7 +50,7 @@ a directory, or source-code archive (e.g., tar.gz).
 : Write the output to _file_. By default, it writes to standard output.
 
 `-${JOBS_FLAG_SHORT}` _num_, `--${JOBS_FLAG_LONG}`=_num_
-: Allow up to _num_ threads for source parsing. The default is 4.
+: Allow up to _num_ threads for source parsing. See the `--${JOBS_FLAG_LONG}` description in the help command to see the default on your machine.
 
 # CREATING SRCML
 

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -383,7 +383,7 @@ srcml archive.xml --xpath "//src:unit/@filename"
 : Execute the XPath query on archive.xml, outputting the filename attribute
 of each unit in the archive to standard out.
 
-# RETURN STATUS
+# EXIT STATUS
 
 ${STATUS_SUCCESS}: Normal
 

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -288,26 +288,41 @@ last modified time based on the archive files.
 
 ## Examples
 
-srcml input.cpp
-: Create a srcML unit from input.cpp, using C++ parsing rules,
+Create a srcML unit from input.cpp, using C++ parsing rules,
 and output to standard out.
 
-echo "int a;" | srcml -${LANGUAGE_FLAG_SHORT} C++
-: Create a srcML unit from standard input, using C++ parsing rules,
+```console
+$ srcml input.cpp
+```
+
+Create a srcML unit from standard input, using C++ parsing rules,
 and output to standard out.
 
-srcml --text="int a;\n" -${LANGUAGE_FLAG_SHORT} C++
-: Create a srcML unit from the expanded text, using C++ parsing rules,
+```console
+$ echo "int a;" | srcml -${LANGUAGE_FLAG_SHORT} C++
+```
+
+Create a srcML unit from the expanded text, using C++ parsing rules,
 and output to standard out.
 
-srcml dir.xml --${SHOW_UNIT_COUNT_FLAG_LONG}
-: Create a srcML archive from all files contained in the dir directory, using
+```console
+$ srcml --text="int a;\n" -${LANGUAGE_FLAG_SHORT} C++
+```
+
+Create a srcML archive from all files contained in the dir directory, using
 their extensions to determine the markup parsing rules, and
 output the number of units contained in the archive to standard out.
 
-srcml input.java --${CPP_FLAG_LONG}
-: Create a srcML unit from input.java, using Java parsing
+```console
+$ srcml dir --${SHOW_UNIT_COUNT_FLAG_LONG}
+```
+
+Create a srcML unit from input.java, using Java parsing
 rules as well as C++ parsing rules for preprocessor directives.
+
+```console
+$ srcml input.java --${CPP_FLAG_LONG}
+```
 
 # EXTRACTING SOURCE CODE
 
@@ -330,14 +345,20 @@ _directory>_
 
 ## Examples
 
-srcml dir/ -${OUTPUT_FLAG_SHORT} dir.xml
-: Create a srcML archive from all files contained in the dir directory, using
+Create a srcML archive from all files contained in the dir directory, using
 their extensions to determine the markup parsing rules, and
 write the resulting srcML archive to dir.xml.
 
-srcml archive.xml --${TO_DIR_FLAG_LONG}=.
-: Re-create all files based on the srcML units in archive.xml, using the current
+```console
+$ srcml dir -${OUTPUT_FLAG_SHORT} dir.xml
+```
+
+Re-create all files based on the srcML units in archive.xml, using the current
 directory as the root directory.
+
+```console
+$ srcml archive.xml --${TO_DIR_FLAG_LONG}=.
+```
 
 # TRANSFORMATIONS
 
@@ -380,14 +401,19 @@ This is an experimental feature and only srcQL queries without verbs are allowed
 
 ## Examples
 
-srcml a.cpp --${XPATH_OPTION_LONG}="//src:name" --${ATTRIBUTE_LONG}="q:foo=test" --${XMLNS_FLAG}:q=mysite.net
-
-: Convert a.cpp to srcML and add the attribute `q:foo=test` to all `src:name`
+Convert a.cpp to srcML and add the attribute `q:foo=test` to all `src:name`
 elements as found by the XPath query. Output the results to standard output.
 
-srcml archive.xml --xpath "//src:unit/@filename"
-: Execute the XPath query on archive.xml, outputting the filename attribute
+```console
+$ srcml a.cpp --${XPATH_OPTION_LONG}="//src:name" --${ATTRIBUTE_LONG}="q:foo=test" --${XMLNS_FLAG}:q=mysite.net
+```
+
+Execute the XPath query on archive.xml, outputting the filename attribute
 of each unit in the archive to standard out.
+
+```console
+$ srcml archive.xml --xpath "//src:unit/@filename"
+```
 
 # EXIT STATUS
 

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -385,11 +385,11 @@ of each unit in the archive to standard out.
 
 # EXIT STATUS
 
-${STATUS_SUCCESS}: Normal
+**${STATUS_SUCCESS}**: Normal
 
-${STATUS_ERROR}: General error
+**${STATUS_ERROR}**: General error
 
-${STATUS_INTERNAL_ERROR}: Internal error
+**${STATUS_INTERNAL_ERROR}**: Internal error
 
 # CAVEATS
 

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -211,6 +211,8 @@ predefined prefix. The predefined URLs and prefixes are:
 
 This set of options allows view and control over various metadata in srcML.
 
+## Viewing Attributes
+
 The following options allow viewing of various metadata stored in the
 srcML document.
 
@@ -252,7 +254,9 @@ then exit.
 `--${PREFIX_FLAG_LONG}`=_url_
 : Display a prefix given by a _url_ and exit.
 
-The following options allow the user to control the attributes:
+## Setting Attributes
+
+The following options allow the user to set the attributes:
 
 `-${FILENAME_FLAG_SHORT}` _filename_, `--${FILENAME_FLAG_LONG}`=_filename_
 : The value of the filename attribute is typically obtained from the input

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -137,7 +137,7 @@ srcml --text="a;" -l C++ --output-srcml-inner
 
 ```<expr_stmt><expr><name>a</name></expr>;</expr_stmt>```
 
-## MARKUP OPTIONS
+# MARKUP OPTIONS
 
 Optional line and column attributes indicate the position of
 an element in the original source code. Both the line and
@@ -175,7 +175,7 @@ should be treated as source code and marked up accordingly.
 : Only place source code in \#else and \#elif regions, leaving out markup.
 The default is to mark up these regions.
 
-## XML FORMAT
+# XML FORMAT
 
 The following options control the format of the XML.
 
@@ -207,7 +207,7 @@ predefined prefix. The predefined URLs and prefixes are:
     `--${XMLNS_FLAG}:${SRCML_CPP_NS_PREFIX_DEFAULT}=${SRCML_CPP_NS_URL}`
     `--${XMLNS_FLAG}:${SRCML_EXT_POSITION_NS_PREFIX_DEFAULT}=${SRCML_EXT_POSITION_NS_URL}`
 
-## METADATA OPTIONS
+# METADATA OPTIONS
 
 This set of options allows view and control over various metadata in srcML.
 
@@ -280,7 +280,7 @@ working with srcML archives.
 time of the input source-code archive. This is the
 last modified time based on the archive files.
 
-## EXAMPLES
+## Examples
 
 srcml input.cpp
 : Create a srcML unit from input.cpp, using C++ parsing rules,
@@ -303,7 +303,7 @@ srcml input.java --${CPP_FLAG_LONG}
 : Create a srcML unit from input.java, using Java parsing
 rules as well as C++ parsing rules for preprocessor directives.
 
-## EXTRACTING SOURCE CODE
+# EXTRACTING SOURCE CODE
 
 The following describe options that are only applicable when
 the output is in source-code format.
@@ -322,7 +322,7 @@ _directory>_
 `-${NULL_SEPARATOR_SHORT}`, `--${NULL_SEPARATOR_LONG}`
 : Separates each source code unit with an ASCII NULL ('\0')
 
-## EXAMPLES
+## Examples
 
 srcml dir/ -${OUTPUT_FLAG_SHORT} dir.xml
 : Create a srcML archive from all files contained in the dir directory, using
@@ -333,7 +333,7 @@ srcml archive.xml --${TO_DIR_FLAG_LONG}=.
 : Re-create all files based on the srcML units in archive.xml, using the current
 directory as the root directory.
 
-## TRANSFORMATIONS
+# TRANSFORMATIONS
 
 `--${XPATH_OPTION_LONG}=`_expression_
 : Query each individual unit using the XPath _expression_. Multiple XPath expression options are allowed.
@@ -372,7 +372,7 @@ This is an experimental feature and only srcQL queries without verbs are allowed
 : Output units matching the RELAXNG _file_ or _url_.
 
 
-## EXAMPLES
+## Examples
 
 srcml a.cpp --${XPATH_OPTION_LONG}="//src:name" --${ATTRIBUTE_LONG}="q:foo=test" --${XMLNS_FLAG}:q=mysite.net
 
@@ -383,7 +383,7 @@ srcml archive.xml --xpath "//src:unit/@filename"
 : Execute the XPath query on archive.xml, outputting the filename attribute
 of each unit in the archive to standard out.
 
-## RETURN STATUS
+# RETURN STATUS
 
 ${STATUS_SUCCESS}: Normal
 
@@ -391,7 +391,7 @@ ${STATUS_ERROR}: General error
 
 ${STATUS_INTERNAL_ERROR}: Internal error
 
-## CAVEATS
+# CAVEATS
 
 Translation is performed based on local information with no symbol
 table. For non-CFG languages, i.e., C/C++, and with macros this may lead
@@ -399,7 +399,7 @@ to incorrect markup.
 
 Line endings are normalized in XML formats including srcML.
 
-## BUGS
+# BUGS
 
 Libxml2 directly supports many encodings beyond UTF-8, UTF-16, and
 ISO-8859-1 through iconv. However, the BOM (Byte Order Mark) immediately
@@ -409,12 +409,12 @@ version of the encoding, e.g., UTF-32BE, UTF-32LE, instead.
 
 Report bugs at Contact us at http://www.srcml.org/support.html
 
-## AUTHORS
+# AUTHORS
 
 Written by Michael L. Collard, Michael Decker, Drew Guarnera, Brian Bartman, 
 and Heather Michaud.
 
-## COPYRIGHT
+# COPYRIGHT
 
 Copyright (C) 2013-2025 srcML, LLC. (www.srcML.org)
 

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -129,13 +129,15 @@ namespace declarations and does not necessarily have a single root element.
 
 ## Examples
 
-srcml --text="a;" -l C++ --output-srcml-outer
+```console
+$ srcml --text="a;" -l C++ --output-srcml-outer
+<unit revision="1.0.0" language="C++"><expr_stmt><expr><name>a</name></expr>;</expr_stmt></unit>
+```
 
-```<unit revision="1.0.0" language="C++"><expr_stmt><expr><name>a</name></expr>;</expr_stmt></unit>```
-
-srcml --text="a;" -l C++ --output-srcml-inner
-
-```<expr_stmt><expr><name>a</name></expr>;</expr_stmt>```
+```console
+$ srcml --text="a;" -l C++ --output-srcml-inner
+<expr_stmt><expr><name>a</name></expr>;</expr_stmt>
+```
 
 # MARKUP OPTIONS
 


### PR DESCRIPTION
Implement improvements in #2122 

- Update copyright date
- Fix wrong heading level in manpage
- Change manpage section 'RETURN STATUS' to 'EXIT STATUS'
- Bold exit status values
- Clarify defaults
- Add subsections for the METADATA OPTIONS
- Remove hard-coded default for  option and refer to client help
- Add $ to mark command lines and show immediate output
- Change order of examples from command -> description to description->command
- Fix escaped meta-characters
- Fix improper COMMENT form
