### PR TITLE
Fix ordering unification issue with Python swap assignment

### DIFF
--- a/src/libsrcml/qli_extensions.cpp
+++ b/src/libsrcml/qli_extensions.cpp
@@ -129,18 +129,6 @@ void add_element(xmlXPathParserContext* ctxt, int nargs) {
 
         const xmlNode* node = node_set.get()->nodeTab[i];
 
-        // check for invalid elements
-        const std::string_view nodeURI((char *) node->ns->href);
-        const std::string_view nodeName((char*) node->name);
-        const bool invalidElement = ("operator"sv == nodeName ||
-                                    "comment"sv == nodeName ||
-                                    "modifier"sv == nodeName ||
-                                    "specifier"sv == nodeName) && "http://www.srcML.org/srcML/src"sv == nodeURI;
-        if (invalidElement) {
-            xmlXPathReturnBoolean(ctxt, false);
-            return;
-        }
-
         const std::string token(get_node_text(node));
         const auto node_ptr = reinterpret_cast<std::uintptr_t>(node);
 
@@ -283,10 +271,8 @@ void clear_elements(xmlXPathParserContext* ctxt, int nargs) {
     UnificationTable* table = (UnificationTable*)(ctxt->context->userData);
 
     if (nargs == 0) {
-
         // clear all buckets
         table->empty_buckets();
-
     } else if (nargs == 1) {
 
         // clear this bucket

--- a/src/libsrcml/xpath_generator.cpp
+++ b/src/libsrcml/xpath_generator.cpp
@@ -201,6 +201,7 @@ XPathNode* XPathGenerator::get_xpath_from_argument(std::string src_query) {
     XPathNode* xpath_root = new XPathNode();
     convert_traverse(srcml_root, xpath_root);
     organize_add_calls(xpath_root);
+    add_sibling_count_predicates(xpath_root);
     // add_bucket_clears(xpath_root);
     return xpath_root;
 }
@@ -810,8 +811,59 @@ void XPathGenerator::organize_add_calls(XPathNode* x_node) {
     if (x_node->is_variable_node()) {
         x_node->add_child(x_node->pop_child_beginning());
     }
-    for (auto xnode : x_node->get_children()) {
-        organize_add_calls(xnode);
+    for (auto child : x_node->get_children()) {
+        organize_add_calls(child);
+    }
+}
+
+// Counts all following-sibling chains and adds a predicate which pre-enforces (>=) this count
+void XPathGenerator::add_sibling_count_predicates(XPathNode* x_node) {
+    // Loop through children, look for a "following-sibling" predicate
+    bool sibling_pred_found = false;
+    for (auto child : x_node->get_children()) {
+        if (child->get_type() == PREDICATE && child->get_text().find("following-sibling") == 0) {
+            sibling_pred_found = true;
+        }
+    }
+    if (sibling_pred_found) {
+        std::map<std::string,int> sibling_map;
+        bool loop = true;
+        XPathNode* current_node = x_node;
+        while (loop) {
+            bool found = false;
+            for (auto child : current_node->get_children()) {
+                if (child->get_type() == PREDICATE && child->get_text().find("following-sibling") == 0) {
+                    found = true;
+                    XPathNode* copy = new XPathNode(*child,true);
+                    copy->set_type(NO_CONN);
+                    std::string sibling_text = copy->to_string();
+                    delete copy;
+                    if (sibling_map.find(sibling_text) == sibling_map.end()) {
+                        sibling_map.insert(std::make_pair(sibling_text,0));
+                    }
+                    sibling_map.at(sibling_text)++;
+                    current_node = child;
+                    break;
+                }
+            }
+            if (!found) {
+                loop = false;
+            }
+        }
+
+        std::string insert_text = "";
+        for (auto sibling : sibling_map) {
+            insert_text += "count(" + sibling.first + ") >= " + std::to_string(sibling.second) + " and ";
+        }
+        insert_text.erase(insert_text.end()-5,insert_text.end());
+
+        XPathNode* sibling_predicate = new XPathNode(insert_text,PREDICATE);
+        x_node->add_child_beginning(sibling_predicate);
+    }
+
+    // Recursive call on children
+    for (auto child : x_node->get_children()) {
+        add_sibling_count_predicates(child);
     }
 }
 
@@ -850,7 +902,7 @@ void XPathGenerator::convert_traverse(xmlNode* top_xml_node, XPathNode* x_node) 
             // If not a variable node
             if (!is_variable_node(node)) {
                 // Special check for converting expr_stmt patterns to include decl_stmt
-                if (get_full_name(node) == "src:expr_stmt" && get_full_name(node->children) == "src:expr" && xmlChildElementCount(node->children) == 1 && get_full_name(node->children->children) == "src:name") {
+                if (!is_no_decl_language() && get_full_name(node) == "src:expr_stmt" && get_full_name(node->children) == "src:expr" && xmlChildElementCount(node->children) == 1 && get_full_name(node->children->children) == "src:name") {
 
                     if (x_node->get_parent() == nullptr) {
                         x_node->set_type(PARENTHESES);
@@ -863,7 +915,7 @@ void XPathGenerator::convert_traverse(xmlNode* top_xml_node, XPathNode* x_node) 
                     }
                 }
                 // Special check for converting expr patterns to include decls
-                else if (get_full_name(node) == "src:expr" && xmlChildElementCount(node) == 1 && get_full_name(node->children) == "src:name") {
+                else if (!is_no_decl_language() && get_full_name(node) == "src:expr" && xmlChildElementCount(node) == 1 && get_full_name(node->children) == "src:name") {
 
                     if (x_node->get_parent() == nullptr) {
                         x_node->set_type(PARENTHESES);
@@ -944,6 +996,7 @@ void XPathGenerator::convert_traverse(xmlNode* top_xml_node, XPathNode* x_node) 
             }
 
         }
+
 
         // Create new XPath node as child of current. 
         // ONLY DO IF NEXT CHILD IS A VALID ELEMENT,
@@ -1036,4 +1089,8 @@ void XPathGenerator::get_variable_info(std::string_view text, std::string& varia
     std::string s = extract_variable(std::string(text));
     variable = s.substr(0,s.find("_"));
     order = stoi(s.substr(s.find("_")+1,s.length()-1));
+}
+
+bool XPathGenerator::is_no_decl_language() {
+    return language == "Python";
 }

--- a/src/libsrcml/xpath_generator.hpp
+++ b/src/libsrcml/xpath_generator.hpp
@@ -22,6 +22,7 @@ private:
     void convert_traverse(xmlNode*, XPathNode*);
     void organize_add_calls(XPathNode*);
     void add_bucket_clears(XPathNode*,int);
+    void add_sibling_count_predicates(XPathNode*);
 
     // XML Node Funcs
     std::string get_full_name(xmlNode*);
@@ -36,6 +37,7 @@ private:
     std::string add_quotes(std::string_view);
     std::string extract_variable(std::string_view);
     void get_variable_info(std::string_view, std::string&, size_t&);
+    bool is_no_decl_language();
 
     // xmlNode* srcml_root;
     // XPathNode* xpath_root;

--- a/src/libsrcml/xpath_node.hpp
+++ b/src/libsrcml/xpath_node.hpp
@@ -21,11 +21,12 @@ public:
     XPathNode() : text(""), type(NO_CONN) {};
     XPathNode(std::string_view _text) : text(_text), type(NO_CONN) {}
     XPathNode(std::string_view _text, NodeConnectionType _type) : text(_text), type(_type) {}
-    XPathNode(const XPathNode&);
+    XPathNode(const XPathNode&, bool special_copy = false);
    ~XPathNode();
 
    friend std::ostream& operator<<(std::ostream&, const XPathNode&);
    std::string to_string(std::string_view rtn = "");
+   void pretty_print(int tabs = 0);
 
    void set_text(std::string_view _text) { text = _text; }
    std::string get_text() { return text; }
@@ -33,7 +34,7 @@ public:
    NodeConnectionType get_type() { return type; }
    std::deque<XPathNode*> get_children() { return children; }
 
-   bool is_variable_node()         { return text.find("*") != std::string::npos && text.find("text()") == std::string::npos; }
+   bool is_variable_node()         { return text.find("*") != std::string::npos && text.find("text()") == std::string::npos && text.find("preceding-sibling") == std::string::npos; }
    bool is_add_call_node()         { return text.find("qli:add-element") != std::string::npos; }
    bool is_match_call_node()       { return text.find("qli:match-element") != std::string::npos; }
    bool is_regex_match_call_node() { return text.find("qli:regex-match") != std::string::npos; }

--- a/test/libsrcml/testsuite/test_srcql.cpp
+++ b/test/libsrcml/testsuite/test_srcql.cpp
@@ -2233,6 +2233,158 @@ int foo(int y) {}
     }
 
 
+    const std::string python_swap_assignments_src = R"(
+x, y = y, x # y
+parent[a], parent[b] = c, c
+d, e, f = {}, {}, {}
+a, b, c = a, c, b # y
+a, b, c = b, a, c # y
+a, b, c = b, c, a # y
+a, b, c = c, a, b # y
+a, b, c = c, b, a # y
+indices[n], indices[m] = indices[m], indices[n] # y
+indices[i], indices[i + 1] = indices[i + 1], indices[i] # y
+a[1], a[2] = a[3], a[4]
+q, q = q, q # y
+(a),(b) = (b),(a) # y
+[a, b], [c, d] = [c, d], [a, b] # y
+[a, b], [c, d] = [a, d], [c, b]
+)";
+
+
+    const std::vector<std::string> python_swap_assignments_expr_srcml = {
+        R"(<expr><tuple><expr><name>x</name></expr>, <expr><name>y</name></expr></tuple> <operator>=</operator> <tuple><expr><name>y</name></expr>, <expr><name>x</name></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><name><name>parent</name><index>[<expr><name>a</name></expr>]</index></name></expr>, <expr><name><name>parent</name><index>[<expr><name>b</name></expr>]</index></name></expr></tuple> <operator>=</operator> <tuple><expr><name>c</name></expr>, <expr><name>c</name></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><name>d</name></expr>, <expr><name>e</name></expr>, <expr><name>f</name></expr></tuple> <operator>=</operator> <tuple><expr><dictionary>{}</dictionary></expr>, <expr><dictionary>{}</dictionary></expr>, <expr><dictionary>{}</dictionary></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr></tuple> <operator>=</operator> <tuple><expr><name>a</name></expr>, <expr><name>c</name></expr>, <expr><name>b</name></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr></tuple> <operator>=</operator> <tuple><expr><name>b</name></expr>, <expr><name>a</name></expr>, <expr><name>c</name></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr></tuple> <operator>=</operator> <tuple><expr><name>b</name></expr>, <expr><name>c</name></expr>, <expr><name>a</name></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr></tuple> <operator>=</operator> <tuple><expr><name>c</name></expr>, <expr><name>a</name></expr>, <expr><name>b</name></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr></tuple> <operator>=</operator> <tuple><expr><name>c</name></expr>, <expr><name>b</name></expr>, <expr><name>a</name></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><name><name>indices</name><index>[<expr><name>n</name></expr>]</index></name></expr>, <expr><name><name>indices</name><index>[<expr><name>m</name></expr>]</index></name></expr></tuple> <operator>=</operator> <tuple><expr><name><name>indices</name><index>[<expr><name>m</name></expr>]</index></name></expr>, <expr><name><name>indices</name><index>[<expr><name>n</name></expr>]</index></name></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><name><name>indices</name><index>[<expr><name>i</name></expr>]</index></name></expr>, <expr><name><name>indices</name><index>[<expr><name>i</name> <operator>+</operator> <literal type="number">1</literal></expr>]</index></name></expr></tuple> <operator>=</operator> <tuple><expr><name><name>indices</name><index>[<expr><name>i</name> <operator>+</operator> <literal type="number">1</literal></expr>]</index></name></expr>, <expr><name><name>indices</name><index>[<expr><name>i</name></expr>]</index></name></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><name><name>a</name><index>[<expr><literal type="number">1</literal></expr>]</index></name></expr>, <expr><name><name>a</name><index>[<expr><literal type="number">2</literal></expr>]</index></name></expr></tuple> <operator>=</operator> <tuple><expr><name><name>a</name><index>[<expr><literal type="number">3</literal></expr>]</index></name></expr>, <expr><name><name>a</name><index>[<expr><literal type="number">4</literal></expr>]</index></name></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><name>q</name></expr>, <expr><name>q</name></expr></tuple> <operator>=</operator> <tuple><expr><name>q</name></expr>, <expr><name>q</name></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><operator>(</operator><name>a</name><operator>)</operator></expr>,<expr><operator>(</operator><name>b</name><operator>)</operator></expr></tuple> <operator>=</operator> <tuple><expr><operator>(</operator><name>b</name><operator>)</operator></expr>,<expr><operator>(</operator><name>a</name><operator>)</operator></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><array>[<expr><name>a</name></expr>, <expr><name>b</name></expr>]</array></expr>, <expr><array>[<expr><name>c</name></expr>, <expr><name>d</name></expr>]</array></expr></tuple> <operator>=</operator> <tuple><expr><array>[<expr><name>c</name></expr>, <expr><name>d</name></expr>]</array></expr>, <expr><array>[<expr><name>a</name></expr>, <expr><name>b</name></expr>]</array></expr></tuple></expr>)",
+        R"(<expr><tuple><expr><array>[<expr><name>a</name></expr>, <expr><name>b</name></expr>]</array></expr>, <expr><array>[<expr><name>c</name></expr>, <expr><name>d</name></expr>]</array></expr></tuple> <operator>=</operator> <tuple><expr><array>[<expr><name>a</name></expr>, <expr><name>d</name></expr>]</array></expr>, <expr><array>[<expr><name>c</name></expr>, <expr><name>b</name></expr>]</array></expr></tuple></expr>)",
+    };
+
+    const std::vector<std::string> python_swap_assignments_expr_stmt_srcml = {
+        R"(<expr_stmt><expr><tuple><expr><name>x</name></expr>, <expr><name>y</name></expr></tuple> <operator>=</operator> <tuple><expr><name>y</name></expr>, <expr><name>x</name></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><name><name>parent</name><index>[<expr><name>a</name></expr>]</index></name></expr>, <expr><name><name>parent</name><index>[<expr><name>b</name></expr>]</index></name></expr></tuple> <operator>=</operator> <tuple><expr><name>c</name></expr>, <expr><name>c</name></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><name>d</name></expr>, <expr><name>e</name></expr>, <expr><name>f</name></expr></tuple> <operator>=</operator> <tuple><expr><dictionary>{}</dictionary></expr>, <expr><dictionary>{}</dictionary></expr>, <expr><dictionary>{}</dictionary></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr></tuple> <operator>=</operator> <tuple><expr><name>a</name></expr>, <expr><name>c</name></expr>, <expr><name>b</name></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr></tuple> <operator>=</operator> <tuple><expr><name>b</name></expr>, <expr><name>a</name></expr>, <expr><name>c</name></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr></tuple> <operator>=</operator> <tuple><expr><name>b</name></expr>, <expr><name>c</name></expr>, <expr><name>a</name></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr></tuple> <operator>=</operator> <tuple><expr><name>c</name></expr>, <expr><name>a</name></expr>, <expr><name>b</name></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr></tuple> <operator>=</operator> <tuple><expr><name>c</name></expr>, <expr><name>b</name></expr>, <expr><name>a</name></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><name><name>indices</name><index>[<expr><name>n</name></expr>]</index></name></expr>, <expr><name><name>indices</name><index>[<expr><name>m</name></expr>]</index></name></expr></tuple> <operator>=</operator> <tuple><expr><name><name>indices</name><index>[<expr><name>m</name></expr>]</index></name></expr>, <expr><name><name>indices</name><index>[<expr><name>n</name></expr>]</index></name></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><name><name>indices</name><index>[<expr><name>i</name></expr>]</index></name></expr>, <expr><name><name>indices</name><index>[<expr><name>i</name> <operator>+</operator> <literal type="number">1</literal></expr>]</index></name></expr></tuple> <operator>=</operator> <tuple><expr><name><name>indices</name><index>[<expr><name>i</name> <operator>+</operator> <literal type="number">1</literal></expr>]</index></name></expr>, <expr><name><name>indices</name><index>[<expr><name>i</name></expr>]</index></name></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><name><name>a</name><index>[<expr><literal type="number">1</literal></expr>]</index></name></expr>, <expr><name><name>a</name><index>[<expr><literal type="number">2</literal></expr>]</index></name></expr></tuple> <operator>=</operator> <tuple><expr><name><name>a</name><index>[<expr><literal type="number">3</literal></expr>]</index></name></expr>, <expr><name><name>a</name><index>[<expr><literal type="number">4</literal></expr>]</index></name></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><name>q</name></expr>, <expr><name>q</name></expr></tuple> <operator>=</operator> <tuple><expr><name>q</name></expr>, <expr><name>q</name></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><operator>(</operator><name>a</name><operator>)</operator></expr>,<expr><operator>(</operator><name>b</name><operator>)</operator></expr></tuple> <operator>=</operator> <tuple><expr><operator>(</operator><name>b</name><operator>)</operator></expr>,<expr><operator>(</operator><name>a</name><operator>)</operator></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><array>[<expr><name>a</name></expr>, <expr><name>b</name></expr>]</array></expr>, <expr><array>[<expr><name>c</name></expr>, <expr><name>d</name></expr>]</array></expr></tuple> <operator>=</operator> <tuple><expr><array>[<expr><name>c</name></expr>, <expr><name>d</name></expr>]</array></expr>, <expr><array>[<expr><name>a</name></expr>, <expr><name>b</name></expr>]</array></expr></tuple></expr></expr_stmt>)",
+        R"(<expr_stmt><expr><tuple><expr><array>[<expr><name>a</name></expr>, <expr><name>b</name></expr>]</array></expr>, <expr><array>[<expr><name>c</name></expr>, <expr><name>d</name></expr>]</array></expr></tuple> <operator>=</operator> <tuple><expr><array>[<expr><name>a</name></expr>, <expr><name>d</name></expr>]</array></expr>, <expr><array>[<expr><name>c</name></expr>, <expr><name>b</name></expr>]</array></expr></tuple></expr></expr_stmt>)",
+    };
+
+    // $LEFT, $RIGHT = $RIGHT, $LEFT
+    {
+        char* s;
+        size_t size;
+
+        srcml_archive* oarchive = srcml_archive_create();
+        srcml_archive_write_open_memory(oarchive,&s, &size);
+
+        srcml_unit* unit = srcml_unit_create(oarchive);
+        srcml_unit_set_language(unit,"Python");
+        srcml_unit_parse_memory(unit,python_swap_assignments_src.c_str(),python_swap_assignments_src.size());
+        dassert(srcml_archive_write_unit(oarchive,unit), SRCML_STATUS_OK);
+
+        srcml_unit_free(unit);
+        srcml_archive_close(oarchive);
+        srcml_archive_free(oarchive);
+
+        std::string srcml_text = std::string(s, size);
+        free(s);
+
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,srcml_text.c_str(),srcml_text.size());
+        dassert(srcml_append_transform_srcql(iarchive,"$LEFT, $RIGHT = $RIGHT, $LEFT"), SRCML_STATUS_OK);
+
+        unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 11);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), python_swap_assignments_expr_srcml[0]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,1)), python_swap_assignments_expr_srcml[3]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,2)), python_swap_assignments_expr_srcml[4]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,3)), python_swap_assignments_expr_srcml[5]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,4)), python_swap_assignments_expr_srcml[6]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,5)), python_swap_assignments_expr_srcml[7]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,6)), python_swap_assignments_expr_srcml[8]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,7)), python_swap_assignments_expr_srcml[9]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,8)), python_swap_assignments_expr_srcml[11]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,9)), python_swap_assignments_expr_srcml[12]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,10)), python_swap_assignments_expr_srcml[13]);
+
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+    // FIND src:expr_stmt CONTAINS $LEFT, $RIGHT = $RIGHT, $LEFT
+    {
+        char* s;
+        size_t size;
+
+        srcml_archive* oarchive = srcml_archive_create();
+        srcml_archive_write_open_memory(oarchive,&s, &size);
+
+        srcml_unit* unit = srcml_unit_create(oarchive);
+        srcml_unit_set_language(unit,"Python");
+        srcml_unit_parse_memory(unit,python_swap_assignments_src.c_str(),python_swap_assignments_src.size());
+        dassert(srcml_archive_write_unit(oarchive,unit), SRCML_STATUS_OK);
+
+        srcml_unit_free(unit);
+        srcml_archive_close(oarchive);
+        srcml_archive_free(oarchive);
+
+        std::string srcml_text = std::string(s, size);
+        free(s);
+
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,srcml_text.c_str(),srcml_text.size());
+        dassert(srcml_append_transform_srcql(iarchive,"FIND src:expr_stmt CONTAINS $LEFT, $RIGHT = $RIGHT, $LEFT"), SRCML_STATUS_OK);
+
+        unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 11);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), python_swap_assignments_expr_stmt_srcml[0]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,1)), python_swap_assignments_expr_stmt_srcml[3]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,2)), python_swap_assignments_expr_stmt_srcml[4]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,3)), python_swap_assignments_expr_stmt_srcml[5]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,4)), python_swap_assignments_expr_stmt_srcml[6]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,5)), python_swap_assignments_expr_stmt_srcml[7]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,6)), python_swap_assignments_expr_stmt_srcml[8]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,7)), python_swap_assignments_expr_stmt_srcml[9]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,8)), python_swap_assignments_expr_stmt_srcml[11]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,9)), python_swap_assignments_expr_stmt_srcml[12]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,10)), python_swap_assignments_expr_stmt_srcml[13]);
+
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
+
     const std::string call_expressions = R"(
 foo();
 bar();


### PR DESCRIPTION
This PR fixes an issue with unification that appeared on specific queries. Python's swap assignment syntax was one such place

Because XPaths are breadth-first, both tuples were being grabbed before any additional checks could be made to rule out right-side tuples for left-side values.

This change addresses this by calculating all "following-sibling" chains in an XPath, and adding them as an ordering check before any other evaluation is done.

For example, with `FIND $LEFT, $RIGHT = $RIGHT, $LEFT`, the XPath will now check that the left tuple has 1 = following it and 1 tuple following it.

With `FIND $A + $B + $C`, `$A` will check for 2 +'s and 2 values, `$B` will check for 1 + and 1 value, and so on.

This may have some positive performance implications for very specific circumstances, such as very long expressions. However the current testsuite did not see any significant speed increase.

This PR also adds the ability to "pretty-print" generated XPaths - an invaluable tool for debugging.

Additionally, a test has been added for this issue as well as the last srcQL issue (Querying for `expr` instead of `expr_stmt`.) and cleans up some redundant code.

Closes #2135 