### PR TITLE
issue2086

### DIFF
--- a/doc/manpage/CMakeLists.txt
+++ b/doc/manpage/CMakeLists.txt
@@ -127,6 +127,9 @@ set(PRETTY_FLAG_LONG "pretty")
 set(NULL_SEPARATOR_LONG "print0")
 set(NULL_SEPARATOR_SHORT "Z")
 
+set(SRCQL_WARNING_OFF_FLAG_LONG "srcql-warning-off")
+set(SRCQL_WARNING_OFF_FLAG_SHORT "F")
+
 # Custom commands for creating things using pandoc
 configure_file(${CMAKE_SOURCE_DIR}/doc/manpage/srcml.cfg ${CMAKE_BINARY_DIR}/srcml.md)
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/srcml.1

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -362,38 +362,38 @@ $ srcml archive.xml --${TO_DIR_FLAG_LONG}=.
 
 # TRANSFORMATIONS
 
+Query the srcML using XPath, RelaxNG, and srcQl. The queries can extract the matched code, insert a custom attribute on the matched code, or wrap the matched code with a custom element. Transformations using XSLT are also supported.
+
 `--${XPATH_OPTION_LONG}=`_expression_
 : Query each individual unit using the XPath _expression_. Multiple XPath expression options are allowed.
 
-The default prefix cannot be used in XPath expressions. Element names must have a prefix, e.g., `src`, `cpp`, etc. Path from the root is required.
+    The default prefix cannot be used in XPath expressions. Element names must have a prefix, e.g., `src`, `cpp`, etc. Path from the root is required.
 
-By default, the result is a srcML archive where each unit is a query result, marked with the original filename. As an alternative, the original srcML can be preserved with the query results marked with an attribute, wrapped with an element, or both. Note that the prefix and url used for the namespace
-must be declared with the option `--${XMLNS_FLAG}:`.
+    By default, the result is a srcML archive where each unit is a query result, marked with the original filename. As an alternative, the original srcML can be preserved with the query results marked with an attribute, wrapped with an element, or both. Note that the prefix and url used for the namespace must be declared with the option `--${XMLNS_FLAG}:`.
 
 `--${SRCQL_OPTION_LONG}=`_query_
 : Query each individual unit using the srcQL _query_. Multiple srcQL query options allowed.
 
-Very similar results to the XPath option `--${XPATH_OPTION_LONG}`.
+    Very similar results to the XPath option `--${XPATH_OPTION_LONG}`.
 
-srcQL queries are written in source-code fragments with the ability to match multiple instances using logical variables, e.g., all declaration statements are &apos;$T $V;&apos;.
+    srcQL queries are written in source-code fragments with the ability to match multiple instances using logical variables, e.g., all declaration statements are &apos;$T $V;&apos;.
 
-On the command line, demark with single quotes to avoid bash expansion.
+    On the command line, demark with single quotes to avoid bash expansion.
 
-Unification is also supported, e.g., all functions with a parameter type that matches the return type are &apos;$T \$V(\$T)&apos;.
+    Unification is also supported, e.g., all functions with a parameter type that matches the return type are &apos;$T \$V(\$T)&apos;.
 
-This is an experimental feature and only srcQL queries without verbs are allowed.
+    This is an experimental feature and only srcQL queries without verbs are allowed.
 
 `--${SRCQL_WARNING_OFF_FLAG_LONG}`, `-${SRCQL_WARNING_OFF_FLAG_SHORT}`
 : Turn off warning for srcql queries that have no logical variables.
 
-The logical variables in a srcql query start with a `$`, e.g., `$TYPE`. When the srcql query is passed on the command
-line delimited by double quotes, the shell performs variable substitution before the srcml program gets the command line options. E.g., for the command `--srcql="FIND $T $V;"`, the srcql query is passed to the program as `FIND  ;` if T and V are undefined shell variables.
+    The logical variables in a srcql query start with a `$`, e.g., `$TYPE`. When the srcql query is passed on the command
+    line delimited by double quotes, the shell performs variable substitution before the srcml program gets the command line options. E.g., for the command `--srcql="FIND $T $V;"`, the srcql query is passed to the program as `FIND  ;` if T and V are undefined shell variables.
 
-The key to prevent this is to delimit the query with single quotes, as this prevents shell variable expansion. E.g.,
-for the command `--srcql='FIND $T $V;'`, the srcql query is passed to the program as `FIND $T $V;`.
+    The key to prevent this is to delimit the query with single quotes, as this prevents shell variable expansion. E.g.,
+    for the command `--srcql='FIND $T $V;'`, the srcql query is passed to the program as `FIND $T $V;`.
 
-To assist the user in noticing this, if the resulting srcql query does not have a logical variable, a warning is issued. The
-`--${SRCQL_WARNING_OFF_FLAG_LONG}` or `-${SRCQL_WARNING_OFF_FLAG_SHORT}` turns off this warning.
+    To assist the user in noticing this, if the resulting srcql query does not have a logical variable, a warning is issued. This option turns off the warning.
 
 `--${ATTRIBUTE_LONG}` _prefix:name=value_
 : Add the attribute _prefix:name="value"_ to every Xpath expression or srcQL query result.
@@ -401,15 +401,14 @@ To assist the user in noticing this, if the resulting srcql query does not have 
 `--${ELEMENT_LONG}` _prefix:name_
 : Wrap every Xpath expression or srcQL query result with an element of the form _prefix:name_. May be mixed with `--${ATTRIBUTE_LONG}`.
 
+`--${RELAXNG_OPTION_LONG}`=_file_|_url_
+: Output units matching the RELAXNG _file_ or _url_.
+
 `--${XSLT_LONG}` _file_|_url_
 : Apply a transformation from an XSLT _file_ or _url_ to each individual unit.
 
 `--${XSLT_PARAM}` _name_="_value_"
 : Pass the string parameter _name_ with UTF-8 encoded string _value_ to the XSLT program
-
-`--${RELAXNG_OPTION_LONG}`=_file_|_url_
-: Output units matching the RELAXNG _file_ or _url_.
-
 
 ## Examples
 

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -383,6 +383,18 @@ Unification is also supported, e.g., all functions with a parameter type that ma
 
 This is an experimental feature and only srcQL queries without verbs are allowed.
 
+`--${SRCQL_WARNING_OFF_FLAG_LONG}`, `-${SRCQL_WARNING_OFF_FLAG_SHORT}`
+: Turn off warning for srcql queries that have no logical variables.
+
+The logical variables in a srcql query start with a `$`, e.g., `$TYPE`. When the srcql query is passed on the command
+line delimited by double quotes, the shell performs variable substitution before the srcml program gets the command line options. E.g., for the command `--srcql="FIND $T $V;"`, the srcql query is passed to the program as `FIND  ;` if T and V are undefined shell variables.
+
+The key to prevent this is to delimit the query with single quotes, as this prevents shell variable expansion. E.g.,
+for the command `--srcql='FIND $T $V;'`, the srcql query is passed to the program as `FIND $T $V;`.
+
+To assist the user in noticing this, if the resulting srcql query does not have a logical variable, a warning is issued. The
+`--${SRCQL_WARNING_OFF_FLAG_LONG}` or `-${SRCQL_WARNING_OFF_FLAG_SHORT}` turns off this warning.
+
 `--${ATTRIBUTE_LONG}` _prefix:name=value_
 : Add the attribute _prefix:name="value"_ to every Xpath expression or srcQL query result.
 

--- a/src/client/srcml_cli.hpp
+++ b/src/client/srcml_cli.hpp
@@ -23,53 +23,55 @@
 #include <libarchive_utilities.hpp>
 
 // Internal srcml command options
-const unsigned long long SRCML_COMMAND_LONGINFO                  = 1<<0;
-const unsigned long long SRCML_COMMAND_INFO                      = 1<<1;
+const unsigned long long SRCML_COMMAND_LONGINFO                  = 1ull << 0ull;
+const unsigned long long SRCML_COMMAND_INFO                      = 1ull << 1ull;
 
-const unsigned long long SRCML_COMMAND_CPP_TEXT_IF0              = 1<<2;
-const unsigned long long SRCML_COMMAND_CPP_MARKUP_ELSE           = 1<<3;
-const unsigned long long SRCML_COMMAND_QUIET                     = 1<<4;
-const unsigned long long SRCML_COMMAND_VERBOSE                   = 1<<5;
-const unsigned long long SRCML_COMMAND_VERSION                   = 1<<6;
+const unsigned long long SRCML_COMMAND_CPP_TEXT_IF0              = 1ull << 2ull;
+const unsigned long long SRCML_COMMAND_CPP_MARKUP_ELSE           = 1ull << 3ull;
+const unsigned long long SRCML_COMMAND_QUIET                     = 1ull << 4ull;
+const unsigned long long SRCML_COMMAND_VERBOSE                   = 1ull << 5ull;
+const unsigned long long SRCML_COMMAND_VERSION                   = 1ull << 6ull;
 
-const unsigned long long SRCML_COMMAND_XML                       = 1<<7;
-const unsigned long long SRCML_COMMAND_SRC                       = 1<<8;
-const unsigned long long SRCML_COMMAND_LIST                      = 1<<9;
-const unsigned long long SRCML_COMMAND_UNITS                     = 1<<10;
+const unsigned long long SRCML_COMMAND_XML                       = 1ull << 7ull;
+const unsigned long long SRCML_COMMAND_SRC                       = 1ull << 8ull;
+const unsigned long long SRCML_COMMAND_LIST                      = 1ull << 9ull;
+const unsigned long long SRCML_COMMAND_UNITS                     = 1ull << 10ull;
 
-const unsigned long long SRCML_COMMAND_TO_DIRECTORY              = 1<<11;
-const unsigned long long SRCML_COMMAND_TIMESTAMP                 = 1<<12;
+const unsigned long long SRCML_COMMAND_TO_DIRECTORY              = 1ull << 11ull;
+const unsigned long long SRCML_COMMAND_TIMESTAMP                 = 1ull << 12ull;
 
-const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_LANGUAGE    = 1<<13;
-const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_URL         = 1<<14;
-const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_FILENAME    = 1<<15;
-const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_SRC_VERSION = 1<<16;
-const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_TIMESTAMP   = 1<<17;
-const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_HASH        = 1<<18;
-const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_ENCODING    = 1<<19;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_LANGUAGE    = 1ull << 13ull;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_URL         = 1ull << 14ull;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_FILENAME    = 1ull << 15ull;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_SRC_VERSION = 1ull << 16ull;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_TIMESTAMP   = 1ull << 17ull;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_HASH        = 1ull << 18ull;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_ENCODING    = 1ull << 19ull;
 
-const unsigned long long SRCML_COMMAND_NO_COLOR                  = 1<<20;
+const unsigned long long SRCML_COMMAND_NO_COLOR                  = 1ull << 20ull;
 
-const unsigned long long SRCML_COMMAND_UPDATE                    = 1<<21;
+const unsigned long long SRCML_COMMAND_UPDATE                    = 1ull << 21ull;
 
-const unsigned long long SRCML_COMMAND_NOARCHIVE                 = 1<<22;
+const unsigned long long SRCML_COMMAND_NOARCHIVE                 = 1ull << 22ull;
 
-const unsigned long long SRCML_DEBUG_MODE                        = 1<<23;
+const unsigned long long SRCML_DEBUG_MODE                        = 1ull << 23ull;
 
-const unsigned long long SRCML_TIMING_MODE                       = 1<<24;
+const unsigned long long SRCML_TIMING_MODE                       = 1ull << 24ull;
 
-const unsigned long long SRCML_ARCHIVE                           = 1<<25;
+const unsigned long long SRCML_ARCHIVE                           = 1ull << 25ull;
 
-const unsigned long long SRCML_HASH                              = 1<<26;
+const unsigned long long SRCML_HASH                              = 1ull << 26ull;
 
-const unsigned long long SRCML_COMMAND_XML_RAW                   = 1<<27;
-const unsigned long long SRCML_COMMAND_XML_FRAGMENT              = 1<<28;
+const unsigned long long SRCML_COMMAND_XML_RAW                   = 1ull << 27ull;
+const unsigned long long SRCML_COMMAND_XML_FRAGMENT              = 1ull << 28ull;
 
-const unsigned long long SRCML_COMMAND_PARSER_TEST               = 1<<29;
+const unsigned long long SRCML_COMMAND_PARSER_TEST               = 1ull << 29ull;
 
-const unsigned long long SRCML_COMMAND_CAT_XML                   = 1<<30;
+const unsigned long long SRCML_COMMAND_CAT_XML                   = 1ull << 30ull;
 
-const unsigned long long SRCML_COMMAND_NULL                      = 1<<31;
+const unsigned long long SRCML_COMMAND_NULL                      = 1ull << 31ull;
+
+const unsigned long long SRCML_COMMAND_SRCQL_NO_VARIABLE_WARNING = 1ull << 32ull;
 
 // commands that are simple queries on srcml
 const unsigned long long SRCML_COMMAND_INSRCML =

--- a/src/client/srcml_cli.hpp
+++ b/src/client/srcml_cli.hpp
@@ -71,7 +71,7 @@ const unsigned long long SRCML_COMMAND_CAT_XML                   = 1ull << 30ull
 
 const unsigned long long SRCML_COMMAND_NULL                      = 1ull << 31ull;
 
-const unsigned long long SRCML_COMMAND_SRCQL_NO_VARIABLE_WARNING = 1ull << 32ull;
+const unsigned long long SRCML_COMMAND_SRCQL_WARNING_OFF         = 1ull << 32ull;
 
 // commands that are simple queries on srcml
 const unsigned long long SRCML_COMMAND_INSRCML =
@@ -111,7 +111,7 @@ struct srcml_request_t {
 
     std::optional<std::size_t> stdindex;
 
-    int command = 0;
+    unsigned long long command = 0ull;
     std::optional<int> markup_options;
 
     // unit attributes

--- a/src/client/srcml_cli.hpp
+++ b/src/client/srcml_cli.hpp
@@ -23,56 +23,56 @@
 #include <libarchive_utilities.hpp>
 
 // Internal srcml command options
-const int SRCML_COMMAND_LONGINFO                  = 1<<0;
-const int SRCML_COMMAND_INFO                      = 1<<1;
+const unsigned long long SRCML_COMMAND_LONGINFO                  = 1<<0;
+const unsigned long long SRCML_COMMAND_INFO                      = 1<<1;
 
-const int SRCML_COMMAND_CPP_TEXT_IF0              = 1<<2;
-const int SRCML_COMMAND_CPP_MARKUP_ELSE           = 1<<3;
-const int SRCML_COMMAND_QUIET                     = 1<<4;
-const int SRCML_COMMAND_VERBOSE                   = 1<<5;
-const int SRCML_COMMAND_VERSION                   = 1<<6;
+const unsigned long long SRCML_COMMAND_CPP_TEXT_IF0              = 1<<2;
+const unsigned long long SRCML_COMMAND_CPP_MARKUP_ELSE           = 1<<3;
+const unsigned long long SRCML_COMMAND_QUIET                     = 1<<4;
+const unsigned long long SRCML_COMMAND_VERBOSE                   = 1<<5;
+const unsigned long long SRCML_COMMAND_VERSION                   = 1<<6;
 
-const int SRCML_COMMAND_XML                       = 1<<7;
-const int SRCML_COMMAND_SRC                       = 1<<8;
-const int SRCML_COMMAND_LIST                      = 1<<9;
-const int SRCML_COMMAND_UNITS                     = 1<<10;
+const unsigned long long SRCML_COMMAND_XML                       = 1<<7;
+const unsigned long long SRCML_COMMAND_SRC                       = 1<<8;
+const unsigned long long SRCML_COMMAND_LIST                      = 1<<9;
+const unsigned long long SRCML_COMMAND_UNITS                     = 1<<10;
 
-const int SRCML_COMMAND_TO_DIRECTORY              = 1<<11;
-const int SRCML_COMMAND_TIMESTAMP                 = 1<<12;
+const unsigned long long SRCML_COMMAND_TO_DIRECTORY              = 1<<11;
+const unsigned long long SRCML_COMMAND_TIMESTAMP                 = 1<<12;
 
-const int SRCML_COMMAND_DISPLAY_SRCML_LANGUAGE    = 1<<13;
-const int SRCML_COMMAND_DISPLAY_SRCML_URL         = 1<<14;
-const int SRCML_COMMAND_DISPLAY_SRCML_FILENAME    = 1<<15;
-const int SRCML_COMMAND_DISPLAY_SRCML_SRC_VERSION = 1<<16;
-const int SRCML_COMMAND_DISPLAY_SRCML_TIMESTAMP   = 1<<17;
-const int SRCML_COMMAND_DISPLAY_SRCML_HASH        = 1<<18;
-const int SRCML_COMMAND_DISPLAY_SRCML_ENCODING    = 1<<19;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_LANGUAGE    = 1<<13;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_URL         = 1<<14;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_FILENAME    = 1<<15;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_SRC_VERSION = 1<<16;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_TIMESTAMP   = 1<<17;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_HASH        = 1<<18;
+const unsigned long long SRCML_COMMAND_DISPLAY_SRCML_ENCODING    = 1<<19;
 
-const int SRCML_COMMAND_NO_COLOR                  = 1<<20;
+const unsigned long long SRCML_COMMAND_NO_COLOR                  = 1<<20;
 
-const int SRCML_COMMAND_UPDATE                    = 1<<21;
+const unsigned long long SRCML_COMMAND_UPDATE                    = 1<<21;
 
-const int SRCML_COMMAND_NOARCHIVE                 = 1<<22;
+const unsigned long long SRCML_COMMAND_NOARCHIVE                 = 1<<22;
 
-const int SRCML_DEBUG_MODE                        = 1<<23;
+const unsigned long long SRCML_DEBUG_MODE                        = 1<<23;
 
-const int SRCML_TIMING_MODE                       = 1<<24;
+const unsigned long long SRCML_TIMING_MODE                       = 1<<24;
 
-const int SRCML_ARCHIVE                           = 1<<25;
+const unsigned long long SRCML_ARCHIVE                           = 1<<25;
 
-const int SRCML_HASH                              = 1<<26;
+const unsigned long long SRCML_HASH                              = 1<<26;
 
-const int SRCML_COMMAND_XML_RAW                   = 1<<27;
-const int SRCML_COMMAND_XML_FRAGMENT              = 1<<28;
+const unsigned long long SRCML_COMMAND_XML_RAW                   = 1<<27;
+const unsigned long long SRCML_COMMAND_XML_FRAGMENT              = 1<<28;
 
-const int SRCML_COMMAND_PARSER_TEST               = 1<<29;
+const unsigned long long SRCML_COMMAND_PARSER_TEST               = 1<<29;
 
-const int SRCML_COMMAND_CAT_XML                   = 1<<30;
+const unsigned long long SRCML_COMMAND_CAT_XML                   = 1<<30;
 
-const int SRCML_COMMAND_NULL                      = 1<<31;
+const unsigned long long SRCML_COMMAND_NULL                      = 1<<31;
 
 // commands that are simple queries on srcml
-const int SRCML_COMMAND_INSRCML =
+const unsigned long long SRCML_COMMAND_INSRCML =
     SRCML_COMMAND_LONGINFO |
     SRCML_COMMAND_INFO    |
     SRCML_COMMAND_VERSION |

--- a/src/client/srcml_options.hpp
+++ b/src/client/srcml_options.hpp
@@ -12,9 +12,9 @@
 
 class SRCMLOptions {
 public:
-    friend void enable(int option);
+    friend void enable(unsigned long long option);
 
-    static void set(int options) {
+    static void set(unsigned long long options) {
 
         opt = options;
     }
@@ -28,12 +28,12 @@ public:
     static int opt;
 };
 
-inline bool option(int option) {
+inline bool option(unsigned long long option) {
 
     return SRCMLOptions::get() & option;
 }
 
-inline void enable(int option) {
+inline void enable(unsigned long long option) {
 
     SRCMLOptions::opt |= option;
 }

--- a/test/client/testsuite/srcql_attribute_unit.sh
+++ b/test/client/testsuite/srcql_attribute_unit.sh
@@ -39,7 +39,7 @@ check "$result"
 srcml --srcql='$N' a.cpp --xmlns:pre=foo.com --attribute="pre:attr=value"
 check "$result"
 
-srcml --srcql="n" a.cpp --xmlns:pre=foo.com --attribute="pre:attr=value"
+srcml --srcql="n" a.cpp --xmlns:pre=foo.com --attribute="pre:attr=value" --srcql-warning-off
 check "$resultnop"
 
 # from standard input

--- a/test/client/testsuite/srcql_warning.sh
+++ b/test/client/testsuite/srcql_warning.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# @file srcql_warning.sh
+#
+# @copyright Copyright (C) 2025 srcML, LLC. (www.srcML.org)
+
+# test framework
+source $(dirname "$0")/framework_test.sh
+
+defineXML empty <<- 'STDOUT'
+	<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+	<unit xmlns="http://www.srcML.org/srcML/src" revision="REVISION"/>
+STDOUT
+
+defineXML srcml <<- 'STDOUT'
+	<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+	<unit xmlns="http://www.srcML.org/srcML/src" revision="1.0.0">
+
+	<unit revision="1.0.0" language="C++" item="1"><decl><type><name>int</name></type> <name>n</name></decl></unit>
+
+	</unit>
+STDOUT
+
+define error <<- 'STDOUT'
+	\033[31msrcml: WARNING The srcql query 'FIND int '
+	does not contain a srcql logical variable that starts with a \033[1m$\033[0m.
+	\033[31mIf your srcql query was meant to contain a logical variable, then enclose the
+	entire query in single quotes, not double quotes, to prevent shell variable
+	expansion. If not, you can safely ignore this message or disable it with the
+	option \033[1;31m--srcql-warning-off\033[0m \033[31mor \033[1;31m-F\033[0m\033[31m.\033[0m
+
+STDOUT
+
+srcml --text="int n;" -l C++ --srcql='FIND $T $A'
+check "$srcml"
+
+srcml --text="int n;" -l C++ --srcql='FIND $T $A' --srcql-warning-off
+check "$srcml"
+
+srcml --text="int n;" -l C++ --srcql='FIND $T $A' -F
+check "$srcml"
+
+srcml --text="int n;" -l C++ --srcql="FIND int $A"
+check "$empty" "$error"
+
+srcml --text="int n;" -l C++ --srcql="FIND int $A" --srcql-warning-off
+check "$empty"
+
+srcml --text="int n;" -l C++ --srcql="FIND int $A" -F
+check "$empty"


### PR DESCRIPTION
Implement #2086. In addition, expand the SRCML_COMMAND limitation to 32 flags.

- **Convert from int to unsigned long long for command bits**
- **Fix type error**
- **Add warning for srcql queries with no logical variables**
- **Add manpage entry for srcql-warning-off**
- **Clarify descriptions for the transformations**
- **Add client tests for the warning messages**
- **Fix regression due to error message**
