### PR TITLE
srcQL Fixes and Improvements

### DIFF
--- a/src/libsrcml/qli_extensions.cpp
+++ b/src/libsrcml/qli_extensions.cpp
@@ -42,7 +42,6 @@ namespace std {
 namespace {
     // remove leading and trailing whitespace
     std::string_view trim_whitespace(std::string_view str) {
-
         const auto first = str.find_first_not_of(" \t\n\r");
         if (first == std::string::npos)
             return "";
@@ -54,7 +53,6 @@ namespace {
 
     // node text with normalized whitespace
     void get_node_text(const xmlNode* top_node, std::string& text, bool top) {
-
         // process list of nodes
         for (const xmlNode* node = top_node; node != NULL && (!top || node == top_node); node = node->next) {
             if (node->type == XML_TEXT_NODE) {
@@ -78,7 +76,6 @@ namespace {
 
     // node text with normalized whitespace
     std::string get_node_text(const xmlNode* top_node) {
-
         // use single string to avoid copying
         std::string s;
         get_node_text(top_node, s, true);
@@ -87,7 +84,6 @@ namespace {
 }
 
 void add_element(xmlXPathParserContext* ctxt, int nargs) {
-
     if (nargs < 3 || nargs > 5) {
         std::cerr << "Arg arity error" << std::endl;
         return;
@@ -128,18 +124,6 @@ void add_element(xmlXPathParserContext* ctxt, int nargs) {
     for (int i = 0; i < node_set.get()->nodeNr; ++i) {
 
         const xmlNode* node = node_set.get()->nodeTab[i];
-
-        // check for invalid elements
-        const std::string_view nodeURI((char *) node->ns->href);
-        const std::string_view nodeName((char*) node->name);
-        const bool invalidElement = ("operator"sv == nodeName ||
-                                    "comment"sv == nodeName ||
-                                    "modifier"sv == nodeName ||
-                                    "specifier"sv == nodeName) && "http://www.srcML.org/srcML/src"sv == nodeURI;
-        if (invalidElement) {
-            xmlXPathReturnBoolean(ctxt, false);
-            return;
-        }
 
         const std::string token(get_node_text(node));
         const auto node_ptr = reinterpret_cast<std::uintptr_t>(node);
@@ -274,7 +258,6 @@ void match_element(xmlXPathParserContext* ctxt, int nargs) {
 }
 
 void clear_elements(xmlXPathParserContext* ctxt, int nargs) {
-
     if (nargs > 1) {
         std::cerr << "Arg arity error" << std::endl;
         return;
@@ -283,10 +266,8 @@ void clear_elements(xmlXPathParserContext* ctxt, int nargs) {
     UnificationTable* table = (UnificationTable*)(ctxt->context->userData);
 
     if (nargs == 0) {
-
         // clear all buckets
         table->empty_buckets();
-
     } else if (nargs == 1) {
 
         // clear this bucket
@@ -300,7 +281,6 @@ void clear_elements(xmlXPathParserContext* ctxt, int nargs) {
 }
 
 void is_valid_element(xmlXPathParserContext* ctxt, int nargs) {
-
     if (nargs != 1) {
         std::cerr << "Arg arity error" << std::endl;
         return;

--- a/src/libsrcml/xpath_generator.cpp
+++ b/src/libsrcml/xpath_generator.cpp
@@ -17,7 +17,8 @@ std::vector<std::string> split(std::string str, std::string delim) {
         if (sub != "") { res.push_back(sub); }
         pos = end + delim.size();
     }
-    res.push_back(str.substr(pos,str.size()-pos));
+    std::string sub = str.substr(pos,str.size()-pos);
+    if (sub != "") { res.push_back(sub); }
     return res;
 }
 
@@ -440,7 +441,17 @@ std::string XPathGenerator::convert() {
         }
     }
 
-    assert(operations.size() == source_exprs.size()-1);
+    // Check if provided query was invalid
+    if (operations.size() != source_exprs.size()-1) {
+        // Invalid query, return ""
+        return "";
+    }
+    for (auto expr : source_exprs) {
+        if (expr->to_string() == "") {
+            // Invalid query, return ""
+            return "";
+        }
+    }
 
     // WHERE NOT and WHERE COUNT and WITH
     for (size_t i = 0; i < operations.size(); ++i) {

--- a/src/libsrcml/xpath_generator.hpp
+++ b/src/libsrcml/xpath_generator.hpp
@@ -22,6 +22,7 @@ private:
     void convert_traverse(xmlNode*, XPathNode*);
     void organize_add_calls(XPathNode*);
     void add_bucket_clears(XPathNode*,int);
+    void add_sibling_count_predicates(XPathNode*);
 
     // XML Node Funcs
     std::string get_full_name(xmlNode*);
@@ -36,6 +37,7 @@ private:
     std::string add_quotes(std::string_view);
     std::string extract_variable(std::string_view);
     void get_variable_info(std::string_view, std::string&, size_t&);
+    bool is_no_decl_language();
 
     // xmlNode* srcml_root;
     // XPathNode* xpath_root;

--- a/src/libsrcml/xpath_node.hpp
+++ b/src/libsrcml/xpath_node.hpp
@@ -21,11 +21,12 @@ public:
     XPathNode() : text(""), type(NO_CONN) {};
     XPathNode(std::string_view _text) : text(_text), type(NO_CONN) {}
     XPathNode(std::string_view _text, NodeConnectionType _type) : text(_text), type(_type) {}
-    XPathNode(const XPathNode&);
+    XPathNode(const XPathNode&, bool special_copy = false);
    ~XPathNode();
 
    friend std::ostream& operator<<(std::ostream&, const XPathNode&);
    std::string to_string(std::string_view rtn = "");
+   void pretty_print(int tabs = 0);
 
    void set_text(std::string_view _text) { text = _text; }
    std::string get_text() { return text; }
@@ -33,7 +34,7 @@ public:
    NodeConnectionType get_type() { return type; }
    std::deque<XPathNode*> get_children() { return children; }
 
-   bool is_variable_node()         { return text.find("*") != std::string::npos && text.find("text()") == std::string::npos; }
+   bool is_variable_node()         { return text.find("*") != std::string::npos && text.find("text()") == std::string::npos && text.find("preceding-sibling") == std::string::npos; }
    bool is_add_call_node()         { return text.find("qli:add-element") != std::string::npos; }
    bool is_match_call_node()       { return text.find("qli:match-element") != std::string::npos; }
    bool is_regex_match_call_node() { return text.find("qli:regex-match") != std::string::npos; }


### PR DESCRIPTION
This PR adds three main things:
- All of the new fixes and improvements for srcQL that were originally introduced in the `python` branch (including the XPath pretty print)
- libsrcql will now properly cache generated XPaths so that they only needs to be generated once per language per query
- libsrcql, when given invalid srcQL queries (such as `FIND ` or `FIND CONTAINS CONTAINS`), will now return `""` instead of the incorrect XPath.