### PR TITLE
Add srcQL Example

### DIFF
--- a/examples/libsrcml/srcml_srcql.cpp
+++ b/examples/libsrcml/srcml_srcql.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /**
- * @file srcml_xpath.cpp
+ * @file srcml_srcql.cpp
  *
  * @copyright Copyright (C) 2013-2024 srcML, LLC. (www.srcML.org)
  *
@@ -21,7 +21,7 @@ int main(int argc, char * argv[]) {
     srcml_archive* inputArchive = srcml_archive_create();
     srcml_archive_read_open_filename(inputArchive, "project.xml");
 
-    // add the xpath transformation
+    // add the srcQL transformation
     srcml_append_transform_srcql(inputArchive, "FIND $X");
 
     // open the output archive
@@ -33,7 +33,7 @@ int main(int argc, char * argv[]) {
     while ((unit = srcml_archive_read_unit(inputArchive))) {
 
         // apply the transforms
-        // since an XPath transformation can produce multiple units
+        // since a srcQL transformation can produce multiple units
         // from a single input unit, this requires using the srcml_transform_result
         srcml_transform_result* result = nullptr;
         srcml_unit_apply_transforms(inputArchive, unit, &result);

--- a/examples/libsrcml/srcml_srcql.cpp
+++ b/examples/libsrcml/srcml_srcql.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/**
+ * @file srcml_xpath.cpp
+ *
+ * @copyright Copyright (C) 2013-2024 srcML, LLC. (www.srcML.org)
+ *
+ * Example program of the use of the libsrcml C API.
+ *
+ * Applies a srcQL query. The query searches for all decls and exprs
+ *
+ * Equivalent to the srcml command line:
+ *
+ * srcml -j 1 --srcql='FIND $X' project.xml -o srcql.xml
+*/
+
+#include <srcml.h>
+
+int main(int argc, char * argv[]) {
+
+    // open the input archive
+    srcml_archive* inputArchive = srcml_archive_create();
+    srcml_archive_read_open_filename(inputArchive, "project.xml");
+
+    // add the xpath transformation
+    srcml_append_transform_srcql(inputArchive, "FIND $X");
+
+    // open the output archive
+    srcml_archive* outputArchive = srcml_archive_clone(inputArchive);
+    srcml_archive_write_open_filename(outputArchive, "srcql.xml");
+
+    // apply the transformation to the archive
+    srcml_unit* unit = nullptr;
+    while ((unit = srcml_archive_read_unit(inputArchive))) {
+
+        // apply the transforms
+        // since an XPath transformation can produce multiple units
+        // from a single input unit, this requires using the srcml_transform_result
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(inputArchive, unit, &result);
+
+        // write the transform result
+        for (int i = 0; i < srcml_transform_get_unit_size(result); ++i) {
+            srcml_archive_write_unit(outputArchive, srcml_transform_get_unit(result, i));
+        }
+
+        // free the transformation result
+        srcml_transform_free(result);
+
+        // free the input unit
+        srcml_unit_free(unit);
+    }
+
+    // close the archives
+    srcml_archive_close(inputArchive);
+    srcml_archive_close(outputArchive);
+
+    // free the archives
+    srcml_archive_free(inputArchive);
+    srcml_archive_free(outputArchive);
+
+    return 0;
+}


### PR DESCRIPTION
This adds a brief srcQL example to the `examples` directory.

This example was copied from the XPath example, and simply runs `FIND $X` on the same code (`project.xml`).