### PR TITLE
Fix unit tag's revision attribute for Python tests

### DIFF
--- a/test/parser/testsuite/alias_py.py.xml
+++ b/test/parser/testsuite/alias_py.py.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="alias">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import>import <name>random</name> <alias>as <expr><name>rnd</name></expr></alias></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import>import <name>os</name> <alias>as <expr><name>OS</name></expr></alias>, <name>threading</name> <alias>as <expr><name>thrd</name></expr></alias></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>sys</name></from> import <name>audit</name> <alias>as <expr><name>ad</name></expr></alias></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>math</name></from> import <name>pi</name> <alias>as <expr><name>PI</name></expr></alias>, <name>sin</name> <alias>as <expr><name>sine</name></expr></alias></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">"text.txt"</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file</name></expr></alias><block>:<block_content>
     <expr_stmt><expr><call><name><name>file</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"Hello World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <import>import <name>a</name></import>
 </block_content></block><catch>except <expr><name>ImportError</name></expr><block>:<block_content>
@@ -34,7 +34,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><name>a</name></expr></condition><block>:<block_content>
     <case>case <expr><name>b</name></expr> if <condition><expr><name>b</name></expr></condition><block>:<block_content>
         <expr_stmt><expr><name>d</name> <operator>=</operator> <literal type="number">0</literal></expr></expr_stmt>

--- a/test/parser/testsuite/annotation_py.py.xml
+++ b/test/parser/testsuite/annotation_py.py.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="annotation">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>do_nothing</name><parameter_list>()</parameter_list> <annotation>-&gt; <expr><literal type="null">None</literal></expr></annotation><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>annotation</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list> <annotation>-&gt; <expr><literal type="string">"srcML"</literal></expr></annotation><block>:<block_content>
     <return>return <expr><literal type="string">"srcML"</literal></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>annotation</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list> <annotation>-&gt; <expr><array>[<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>]</array></expr></annotation><block>:<block_content>
     <return>return <expr><array>[<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>]</array></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>annotation</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list> <annotation>-&gt; <expr><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>, <argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></annotation><block>:<block_content>
     <return>return <expr><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>, <argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>annotation</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list> <annotation>-&gt; <expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>, <argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call><argument_list>()</argument_list></call></expr></annotation><block>:<block_content>
     <return>return <expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>, <argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call><argument_list>()</argument_list></call></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>example</name><parameter_list>(
     <parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>,
     <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>,
@@ -40,37 +40,37 @@
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>print_square</name><parameter_list>(<parameter><name>x</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>multiply</name><parameter_list>(<parameter><name>a1</name><annotation>: <expr><name>int</name></expr></annotation></parameter>, <parameter><name>a2</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list> <annotation>-&gt; <expr><name>int</name></expr></annotation><block>:<block_content>
     <return>return <expr><name>a1</name><operator>*</operator><name>a2</name></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>printf</name><parameter_list>(<parameter type="args">*<name>args</name><annotation>: <expr><name>tuple</name></expr></annotation></parameter>, <parameter type="kwargs">**<name>kwargs</name><annotation>: <expr><name>dict</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>args</name></expr></argument>,<argument><expr><name>kwargs</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>a</name> <annotation>: <expr><literal type="number">10</literal></expr></annotation></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>Vector</name> <annotation>: <expr><name>TypeAlias</name></expr></annotation> <operator>=</operator> <name><name>list</name><index>[<expr><name>float</name></expr>]</index></name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>out</name><annotation>: <expr><call><name>CustomType</name><argument_list>(<argument><expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr>)</tuple></expr></argument>)</argument_list></call></expr></annotation> <operator>=</operator> <call><name>call_one</name><argument_list>(<argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>out</name><annotation>: <expr><call><call><name>CustomType</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call></expr></annotation> <operator>=</operator> <call><name>call_one</name><argument_list>(<argument><expr><name>c</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 

--- a/test/parser/testsuite/argument_py.py.xml
+++ b/test/parser/testsuite/argument_py.py.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="argument">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>()</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Hello World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Hello"</literal></expr></argument>, <argument><expr><literal type="string">"World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><name>end</name>=<expr><literal type="string">"\t"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Hello"</literal></expr></argument>, <argument><expr><literal type="string">"World"</literal></expr></argument>, <argument><name>sep</name>=<expr><literal type="string">"|"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>process</name><argument_list>(<argument><name>arg1</name>=<expr><name>sample</name></expr></argument>, <argument><name>arg2</name>=<expr><literal type="string">"Name"</literal></expr></argument>, <argument><name>arg3</name>=<expr><literal type="null">None</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 

--- a/test/parser/testsuite/array_py.py.xml
+++ b/test/parser/testsuite/array_py.py.xml
@@ -1,79 +1,79 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="array">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><literal type="number">1</literal></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>, <expr><literal type="number">3</literal></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>, <expr><literal type="number">3</literal></expr>, <expr><literal type="number">4</literal></expr>, <expr><literal type="number">5</literal></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><literal type="number">1</literal></expr>,]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>,]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>=</operator> <array>[]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>=</operator> <array>[<expr><literal type="number">1</literal></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>=</operator> <array>[<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>=</operator> <array>[<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>, <expr><literal type="number">3</literal></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>=</operator> <array>[<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>, <expr><literal type="number">3</literal></expr>, <expr><literal type="number">4</literal></expr>, <expr><literal type="number">5</literal></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><literal type="number">1</literal></expr>,<expr><literal type="string">"type"</literal></expr>,<expr><literal type="null">None</literal></expr>,<expr><name>exec</name></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><name>x</name></expr> <comprehension><for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><array>[]</array></expr>,<expr><array>[]</array></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><array>[<expr><literal type="number">1</literal></expr>,<expr><literal type="number">2</literal></expr>]</array></expr>,<expr><array>[<expr><literal type="number">3</literal></expr>,<expr><literal type="number">4</literal></expr>]</array></expr>,<expr><array>[<expr><literal type="number">5</literal></expr>,<expr><literal type="number">6</literal></expr>]</array></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr>]</array> <operator>=</operator> <array>[<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>, <expr><literal type="number">3</literal></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>empty</name> <operator>=</operator> <operator>(</operator><array>[]</array><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[
     <expr><call><name>subtest</name><argument_list>(
         <argument><expr><tuple>(
@@ -85,7 +85,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[
     <expr><name>a</name></expr>
     <comprehension><for>for <control><expr><name>a</name></expr> <range>in <expr><name>array1</name></expr></range></control></for>
@@ -93,7 +93,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[
     <expr><name>a</name></expr>
     <comprehension><for><specifier>async</specifier> for <control><expr><name>a</name></expr> <range>in <expr><name>array1</name></expr></range></control></for>
@@ -101,7 +101,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[
     <expr><name>a</name></expr>
     <comprehension><for>for <control><expr><name>a</name></expr> <range>in <expr><name>array1</name></expr></range></control></for>
@@ -114,7 +114,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[
     <expr><name>a</name></expr>
     <comprehension><for><specifier>async</specifier> for <control><expr><name>a</name></expr> <range>in <expr><name>array1</name></expr></range></control></for>
@@ -127,7 +127,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[
     <expr><name>a</name></expr>
     <comprehension><for>for <control><expr><name>a</name></expr> <range>in <expr><name>array1</name></expr></range></control></for>
@@ -144,7 +144,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[
     <expr><name>a</name></expr>
     <comprehension><for><specifier>async</specifier> for <control><expr><name>a</name></expr> <range>in <expr><name>array1</name></expr></range></control></for>
@@ -161,7 +161,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[
     <expr><name>a</name></expr>
     <comprehension><for>for <control><expr><name>a</name></expr> <range>in <expr><name>array1</name></expr></range></control></for>
@@ -175,7 +175,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>(</operator>
     <name>a</name>
     <comprehension><for>for <control><expr><name>b</name></expr> <range>in <expr><name>c</name></expr></range></control></for>
@@ -188,7 +188,7 @@
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>(</operator>
     <name>a</name>
     <comprehension><for><specifier>async</specifier> for <control><expr><name>b</name></expr> <range>in <expr><name>c</name></expr></range></control></for>

--- a/test/parser/testsuite/assert_py.py.xml
+++ b/test/parser/testsuite/assert_py.py.xml
@@ -1,83 +1,83 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="assert">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><literal type="boolean">True</literal></expr></condition></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><literal type="number">1</literal> <operator>+</operator> <literal type="number">1</literal> <operator>==</operator> <literal type="number">2</literal></expr></condition></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><operator>not</operator> <literal type="boolean">False</literal></expr></condition></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><literal type="boolean">False</literal></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><set>{<expr><literal type="boolean">True</literal></expr>, <expr><literal type="boolean">False</literal></expr>}</set></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><dictionary>{<expr><literal type="string">'a'</literal></expr>: <expr><name>a</name></expr>, <expr><literal type="string">'b'</literal></expr>: <expr><name>b</name></expr>}</dictionary></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><array>[<expr><name>a</name></expr>, <expr><name>b</name></expr>]</array></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><name><name>a</name><index>[<expr><name>b</name></expr>, <expr><name>c</name></expr>]</index></name></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name>sample</name><argument_list>(<argument><expr><name>a</name></expr></argument>, <argument><expr><name>b</name></expr></argument>)</argument_list></call></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name>sample</name><argument_list>(<argument><expr><call><name>example</name><argument_list>(<argument><expr><name>a</name></expr></argument>, <argument><expr><name>b</name></expr></argument>)</argument_list></call></expr></argument>, <argument><expr><name>c</name></expr></argument>)</argument_list></call></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name>sample</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>: <expr><name>a</name><operator>**</operator><name>b</name></expr></lambda></expr></argument>)</argument_list></call></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name>list</name><argument_list>(<argument><expr><call><name>map</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr></lambda></expr></argument>, <argument><expr><name>numbers</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name>list</name><argument_list>(<argument><expr><call><name>map</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><set>{<expr><name>x</name></expr>, <expr><name>x</name></expr>}</set></expr></lambda></expr></argument>, <argument><expr><name>numbers</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name>list</name><argument_list>(<argument><expr><call><name>map</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><dictionary>{<expr><literal type="string">'x'</literal></expr>: <expr><name>x</name></expr>, <expr><literal type="string">'x'</literal></expr>: <expr><name>x</name></expr>}</dictionary></expr></lambda></expr></argument>, <argument><expr><name>numbers</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name>list</name><argument_list>(<argument><expr><call><name>map</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><array>[<expr><name>x</name></expr>, <expr><name>x</name></expr>]</array></expr></lambda></expr></argument>, <argument><expr><name>numbers</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name>list</name><argument_list>(<argument><expr><call><name>map</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><tuple>(<expr><name>x</name></expr>, <expr><name>x</name></expr>)</tuple></expr></lambda></expr></argument>, <argument><expr><name>numbers</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name>list</name><argument_list>(<argument><expr><call><name>map</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><name><name>x</name><index>[<expr><name>x</name></expr>, <expr><name>x</name></expr>]</index></name></expr></lambda></expr></argument>, <argument><expr><name>numbers</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name><name>a</name><operator>.</operator><name>call_one</name></name><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call><operator>.</operator><name>c</name> <operator>==</operator> <tuple>(<expr><call><name>len</name><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call></expr>,)</tuple></expr></condition></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name><name>a</name><operator>.</operator><name>call_one</name></name><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call><operator>.</operator><name>c</name> <operator>==</operator> <tuple>(<expr><call><name>len</name><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call></expr>, <expr><literal type="number">2</literal></expr>)</tuple></expr></condition></assert>
 </unit>
 

--- a/test/parser/testsuite/attribute_py.py.xml
+++ b/test/parser/testsuite/attribute_py.py.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="attribute">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class><attribute>@<expr><name>unique</name></expr></attribute>
 class <name>Human</name><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class><attribute>@<expr><call><name>operator</name><argument_list>()</argument_list></call></expr></attribute>
 class <name>t_op</name><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class><attribute>@<expr><name>operator</name></expr></attribute>
 <attribute>@<expr><call><name>decorator_getter</name><argument_list>()</argument_list></call></expr></attribute>
 class <name>d_op</name><block>:<block_content>
@@ -23,7 +23,7 @@ class <name>d_op</name><block>:<block_content>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class><attribute>@<expr><name>decorator1</name></expr></attribute>
 <attribute>@<expr><name>decorator2</name></expr></attribute>
 class <name>MyClass</name><block>:<block_content>
@@ -31,7 +31,7 @@ class <name>MyClass</name><block>:<block_content>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class><attribute>@<expr><call><name>decorator1</name><argument_list>()</argument_list></call></expr></attribute>
 <attribute>@<expr><call><name>decorator2</name><argument_list>()</argument_list></call></expr></attribute>
 class <name>MyClass</name><block>:<block_content>
@@ -39,28 +39,28 @@ class <name>MyClass</name><block>:<block_content>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class><attribute>@<expr><name>A</name> <operator>+</operator> <name>B</name></expr></attribute>
 class <name>new_op</name><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><name>print</name></expr></attribute>
 def <name>func</name><parameter_list>()</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><call><name>decorator_getter</name><argument_list>()</argument_list></call></expr></attribute>
 def <name>new</name><parameter_list>()</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><name>decorator1</name></expr></attribute>
 <attribute>@<expr><name>decorator2</name></expr></attribute>
 def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
@@ -68,7 +68,7 @@ def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <par
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><call><name>decorator1</name><argument_list>()</argument_list></call></expr></attribute>
 <attribute>@<expr><call><name>decorator2</name><argument_list>()</argument_list></call></expr></attribute>
 def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
@@ -76,7 +76,7 @@ def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <par
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><call><name><name>pytest</name><operator>.</operator><name>mark</name><operator>.</operator><name>parametrize</name></name><argument_list>(
     <argument><expr><literal type="string">"a"</literal></expr></argument>,
     <argument><expr><array>[
@@ -90,7 +90,7 @@ def <name>sample</name><parameter_list>(<parameter><name>a</name></parameter>)</
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><call><name><name>pytest</name><operator>.</operator><name>mark</name><operator>.</operator><name>parametrize</name></name><argument_list>(
     <argument><expr><literal type="string">"a"</literal></expr></argument>,
     <argument><expr><array>[
@@ -104,7 +104,7 @@ def <name>sample</name><parameter_list>(<parameter><name>a</name></parameter>)</
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><call><name>parameterized</name><argument_list>(
     <argument><expr><array>[
         <expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr>
@@ -117,7 +117,7 @@ def <name>example</name><parameter_list>()</parameter_list><block>:<block_conten
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><call><name>parametrize</name><argument_list>(
     <argument><name>main</name>=<expr><literal type="number">0</literal></expr></argument>,
     <argument><name>operator</name>=<expr><literal type="string">'+'</literal></expr></argument>,
@@ -128,7 +128,7 @@ def <name>_</name><parameter_list>(<parameter><name>default</name></parameter>, 
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><name>decorator</name></expr></attribute>
 <specifier>async</specifier> def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><name>a</name> <operator>+</operator> <name>b</name></expr></return>

--- a/test/parser/testsuite/block_py.py.xml
+++ b/test/parser/testsuite/block_py.py.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="block">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><name>loop</name></expr></condition><block>:<block_content>
     <expr_stmt><expr><name>loop</name> <operator>=</operator> <call><name>check_if_looping</name><argument_list>()</argument_list></call></expr></expr_stmt>
 </block_content></block></while>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><name>loop</name></expr></condition><block>:<block_content>
     <expr_stmt><expr><name>loop</name> <operator>=</operator> <call><name>check_if_looping</name><argument_list>()</argument_list></call></expr></expr_stmt>
 </block_content></block><else>else<block>:<block_content>
@@ -15,14 +15,14 @@
 </block_content></block></else></while>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>value</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>value</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></for>
 </unit>
 
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>value</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>value</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block><else>else<block>:<block_content>
@@ -30,13 +30,13 @@
 </block_content></block></else></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><literal type="boolean">True</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"If"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><literal type="boolean">False</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"If"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></if><if type="elseif">elif <condition><expr><literal type="boolean">True</literal></expr></condition><block>:<block_content>
@@ -46,7 +46,7 @@
 </block_content></block></else></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><name>number</name></expr></condition><block>:<block_content>
     <case>case <expr><literal type="number">1</literal></expr><block>:<block_content>
         <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"one"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
@@ -55,13 +55,13 @@
 </block_content></block></case></block_content></block></switch>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">"test.txt"</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file</name></expr></alias><block>:<block_content>
     <expr_stmt><expr><call><name><name>file</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"Hello World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Try"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block><catch>except<block>:<block_content>
@@ -73,19 +73,19 @@
 </block_content></block></finally></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>printf</name><parameter_list>(<parameter><name>val</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">f"{val}"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>foo</name><parameter_list>()</parameter_list><block>:<block_content>
     <function>def <name>bar</name><parameter_list>()</parameter_list><block>:<block_content>
         <function>def <name>bin</name><parameter_list>()</parameter_list><block>:<block_content>
@@ -93,7 +93,7 @@
 </block_content></block></function></block_content></block></function></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>a</name><parameter_list>()</parameter_list><block>:<block_content>
     <function>def <name>a_a</name><parameter_list>()</parameter_list><block>:<block_content>
         <function>def <name>a_a_a</name><parameter_list>()</parameter_list><block>:<block_content>

--- a/test/parser/testsuite/break_py.py.xml
+++ b/test/parser/testsuite/break_py.py.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="break">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <break>break</break>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><name>loop</name></expr></condition><block>:<block_content>
     <break>break</break>
 </block_content></block></while>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <if_stmt><if>if <condition><expr><name>x</name> <operator>==</operator> <literal type="number">3</literal></expr></condition><block>:<block_content>
         <break>break</break>

--- a/test/parser/testsuite/call_py.py.xml
+++ b/test/parser/testsuite/call_py.py.xml
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="call">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>()</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Hello World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Hello"</literal></expr></argument>, <argument><expr><literal type="string">"World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>value</name> <operator>=</operator> <call><name>eval</name><argument_list>(<argument><expr><literal type="string">"4+6"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>invert</name><argument_list>(<argument><expr><call><name>invert</name><argument_list>(<argument><expr><name>value</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><call><name>get_func</name><argument_list>()</argument_list></call><argument_list>()</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name><name>sample</name><index>[<expr><literal type="string">"a"</literal></expr>]</index></name><argument_list>(<argument><expr><name>b</name></expr></argument>, <argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name><name>sample</name><index>[<expr><literal type="string">"a"</literal></expr>]</index><index>[<expr><literal type="string">"b"</literal></expr>]</index></name><argument_list>(<argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>, <argument><expr><name>e</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <call><name><name>a</name><operator>.</operator><name>b</name><index>[<expr><literal type="string">'default'</literal></expr>]</index></name><argument_list>(
     <argument><name>input</name>=<expr><call><name><name>c</name><operator>.</operator><name>call_one</name></name><argument_list>(<argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></argument>
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <call><name><name>a</name><operator>.</operator><name>b</name><operator>.</operator><name>c</name><index>[<expr><literal type="string">'default'</literal></expr>]</index></name><argument_list>(
     <argument><name>input</name>=<expr><call><name><name>d</name><operator>.</operator><name>call_one</name></name><argument_list>(<argument><expr><name>e</name></expr></argument>)</argument_list></call><index>[<expr><literal type="number">0</literal></expr>]</index></expr></argument>
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <tuple><expr><name><name>a</name><operator>.</operator><name>b</name></name></expr>, <expr><call><name><name>c</name><operator>.</operator><name>d</name><operator>.</operator><name>e</name><index>[<expr><literal type="string">'default'</literal></expr>]</index></name><argument_list>(
     <argument><name>input</name>=<expr><call><name><name>f</name><operator>.</operator><name>call_one</name></name><argument_list>(<argument><expr><name>g</name></expr></argument>)</argument_list></call><index>[<expr><literal type="number">0</literal></expr>]</index></expr></argument>
 )</argument_list></call></expr></tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name><name>result</name><operator>.</operator><name>example</name></name> <operator>=</operator> <call><name><name>a</name><operator>.</operator><name>b</name><operator>.</operator><name>c</name><index>[<expr><literal type="string">'default'</literal></expr>]</index></name><argument_list>(
     <argument><name>input</name>=<expr><call><name><name>d</name><operator>.</operator><name>call_one</name></name><argument_list>(<argument><expr><name>e</name></expr></argument>)</argument_list></call><index>[<expr><literal type="number">0</literal></expr>]</index></expr></argument>
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>example</name><argument_list>(<argument><expr><call><name><name>sample</name><index>[<expr><literal type="string">"a"</literal></expr>]</index></name><argument_list>(<argument><expr><name>b</name></expr></argument>, <argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name><name>example</name><index>[<expr><literal type="string">"a"</literal></expr>]</index></name><argument_list>(<argument><expr><call><name><name>sample</name><index>[<expr><literal type="string">"b"</literal></expr>]</index></name><argument_list>(<argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>, <argument><expr><name>e</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>sample</name><argument_list>(
     <argument><expr><name>a</name> <operator>*</operator> <operator>(</operator>
         <call><name>b</name><argument_list>(<argument><expr><literal type="number">2</literal> <operator>*</operator> <operator>(</operator><name>c</name><operator>)</operator></expr></argument>)</argument_list></call>
@@ -73,7 +73,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>=</operator> <lambda>lambda <parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>, <parameter><name>c</name></parameter>: <expr><call><name>sample</name><argument_list>(
     <argument><expr><name>a</name> <operator>*</operator> <operator>(</operator>
         <call><name>b</name><argument_list>(<argument><expr><literal type="number">2</literal> <operator>*</operator> <operator>(</operator><name>c</name><operator>)</operator></expr></argument>)</argument_list></call>
@@ -81,75 +81,75 @@
 )</argument_list></call></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>(</operator>
     <tuple>(<expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>a</name><argument_list>(<argument><expr><call><name>b</name><argument_list>(<argument><expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></lambda></expr>, <expr><literal type="boolean">False</literal></expr>)</tuple>
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>(</operator>
     <tuple>(<expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>a</name><argument_list>(<argument><expr><call><name>b</name><argument_list>(<argument><expr><tuple>(<expr><operator>(</operator><name>x</name><operator>)</operator></expr>, <expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr>)</tuple></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></lambda></expr>, <expr><literal type="boolean">False</literal></expr>)</tuple>
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(
     <expr><tuple>(<expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>a</name><argument_list>(<argument><expr><call><name>b</name><argument_list>(<argument><expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></lambda></expr>, <expr><literal type="boolean">False</literal></expr>)</tuple></expr>,
     <expr><literal type="boolean">True</literal></expr>
 )</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(
     <expr><tuple>(<expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>a</name><argument_list>(<argument><expr><call><name>b</name><argument_list>(<argument><expr><tuple>(<expr><operator>(</operator><name>x</name><operator>)</operator></expr>, <expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr>)</tuple></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></lambda></expr>, <expr><literal type="boolean">False</literal></expr>)</tuple></expr>,
     <expr><literal type="boolean">True</literal></expr>
 )</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[
     <expr><tuple>(<expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>a</name><argument_list>(<argument><expr><call><name>b</name><argument_list>(<argument><expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></lambda></expr>, <expr><literal type="boolean">False</literal></expr>)</tuple></expr>,
     <expr><literal type="boolean">True</literal></expr>
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[
     <expr><tuple>(<expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>a</name><argument_list>(<argument><expr><call><name>b</name><argument_list>(<argument><expr><tuple>(<expr><operator>(</operator><name>x</name><operator>)</operator></expr>, <expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr>)</tuple></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></lambda></expr>, <expr><literal type="boolean">False</literal></expr>)</tuple></expr>,
     <expr><literal type="boolean">True</literal></expr>
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{
     <expr><tuple>(<expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>a</name><argument_list>(<argument><expr><call><name>b</name><argument_list>(<argument><expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></lambda></expr>, <expr><literal type="boolean">False</literal></expr>)</tuple></expr>,
     <expr><literal type="boolean">True</literal></expr>
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{
     <expr><tuple>(<expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>a</name><argument_list>(<argument><expr><call><name>b</name><argument_list>(<argument><expr><tuple>(<expr><operator>(</operator><name>x</name><operator>)</operator></expr>, <expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr>)</tuple></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></lambda></expr>, <expr><literal type="boolean">False</literal></expr>)</tuple></expr>,
     <expr><literal type="boolean">True</literal></expr>
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{
     <expr><literal type="string">"a"</literal></expr>: <expr><tuple>(<expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>a</name><argument_list>(<argument><expr><call><name>b</name><argument_list>(<argument><expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></lambda></expr>, <expr><literal type="boolean">False</literal></expr>)</tuple></expr>,
     <expr><literal type="string">"b"</literal></expr>: <expr><literal type="boolean">True</literal></expr>
 }</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{
     <expr><literal type="string">"a"</literal></expr>: <expr><tuple>(<expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>a</name><argument_list>(<argument><expr><call><name>b</name><argument_list>(<argument><expr><tuple>(<expr><operator>(</operator><name>x</name><operator>)</operator></expr>, <expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr>)</tuple></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></lambda></expr>, <expr><literal type="boolean">False</literal></expr>)</tuple></expr>,
     <expr><literal type="string">"b"</literal></expr>: <expr><literal type="boolean">True</literal></expr>
 }</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>example</name> <operator>is not</operator> <literal type="null">None</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><name>example</name> <operator>=</operator> <literal type="string">"\n"</literal><operator>.</operator><call><name>join</name><argument_list>(
         <argument><expr><comprehension><for>for <control><expr><name>line</name></expr> <range>in <expr><tuple>(
@@ -161,7 +161,7 @@
 </block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>example</name> <operator>is not</operator> <literal type="null">None</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><name>example</name> <operator>=</operator> <literal type="string">"\n"</literal><operator>.</operator><call><name>join</name><argument_list>(
         <argument><expr><comprehension><for><specifier>async</specifier> for <control><expr><name>line</name></expr> <range>in <expr><tuple>(
@@ -173,7 +173,7 @@
 </block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>example</name> <operator>is not</operator> <literal type="null">None</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><name>example</name> <operator>=</operator> <literal type="string">"\n"</literal><operator>.</operator><call><name>join</name><argument_list>(
         <argument><expr><name>line</name></expr>
@@ -187,7 +187,7 @@
 </block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>example</name> <operator>is not</operator> <literal type="null">None</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><name>example</name> <operator>=</operator> <literal type="string">"\n"</literal><operator>.</operator><call><name>join</name><argument_list>(
         <argument><expr><name>line</name></expr>
@@ -201,7 +201,7 @@
 </block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>example</name><argument_list>(
     <argument><name>input</name>=<expr><operator>(</operator>
         <name>a</name> <ternary>if <condition><expr><literal type="boolean">False</literal></expr></condition> <else>else <expr><call><name>sample</name><argument_list>(<argument><expr><operator>*</operator><call><name>create_array</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></else></ternary>
@@ -209,7 +209,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>example</name><argument_list>(
     <argument><name>input</name>=<expr><operator>(</operator>
         <name>a</name> <ternary>if <condition><expr><literal type="boolean">False</literal></expr></condition> <else>else <expr><call><name>sample</name><argument_list>(<argument><expr><operator>*</operator><call><name>create_array</name><argument_list>(<argument><expr><operator>*</operator><name>a</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></else></ternary>
@@ -217,7 +217,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>example</name><argument_list>(
     <argument><name>input</name>=<expr><operator>(</operator>
         <name>a</name> <ternary>if <condition><expr><literal type="boolean">False</literal></expr></condition> <else>else <expr><call><name>sample</name><argument_list>(<argument><expr><operator>*</operator><name>a</name></expr></argument>)</argument_list></call></expr></else></ternary>
@@ -225,7 +225,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>example</name><argument_list>(
     <argument><name>input</name>=<expr><operator>(</operator>
         <name>a</name> <ternary>if <condition><expr><literal type="boolean">False</literal></expr></condition> <else>else <expr><call><name>sample</name><argument_list>(<argument><expr><operator>*</operator><name>a</name></expr></argument>, <argument><expr><operator>*</operator><name>a</name></expr></argument>)</argument_list></call></expr></else></ternary>
@@ -233,7 +233,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>example</name><argument_list>(
     <argument><name>input</name>=<expr><operator>(</operator>
         <name>d</name> <ternary>if <condition><expr><literal type="boolean">False</literal></expr></condition> <else>else <expr><call><name>sample</name><argument_list>(<argument><expr><operator>**</operator><call><name>create_dict</name><argument_list>(<argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></else></ternary>
@@ -241,7 +241,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>example</name><argument_list>(
     <argument><name>input</name>=<expr><operator>(</operator>
         <name>d</name> <ternary>if <condition><expr><literal type="boolean">False</literal></expr></condition> <else>else <expr><call><name>sample</name><argument_list>(<argument><expr><operator>**</operator><call><name>create_dict</name><argument_list>(<argument><expr><operator>**</operator><name>d</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></else></ternary>
@@ -249,7 +249,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>example</name><argument_list>(
     <argument><name>input</name>=<expr><operator>(</operator>
         <name>d</name> <ternary>if <condition><expr><literal type="boolean">False</literal></expr></condition> <else>else <expr><call><name>sample</name><argument_list>(<argument><expr><operator>**</operator><name>d</name></expr></argument>)</argument_list></call></expr></else></ternary>
@@ -257,7 +257,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>example</name><argument_list>(
     <argument><name>input</name>=<expr><operator>(</operator>
         <name>d</name> <ternary>if <condition><expr><literal type="boolean">False</literal></expr></condition> <else>else <expr><call><name>sample</name><argument_list>(<argument><expr><operator>**</operator><name>d</name></expr></argument>, <argument><expr><operator>**</operator><name>d</name></expr></argument>)</argument_list></call></expr></else></ternary>
@@ -265,18 +265,18 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>sample</name> <operator>=</operator> <call><name><name>a</name><operator>.</operator><name>b</name></name><argument_list>(
     <argument><expr><name>c</name></expr></argument>,
     <argument><expr><lambda>lambda <parameter><name>d</name></parameter>: <expr><call><name>map_arg</name><argument_list>(<argument><expr><name>d</name></expr></argument>, <argument><expr><lambda>lambda <parameter><name>e</name></parameter>: <expr><call><name>load_arg</name><argument_list>(<argument><expr><name>e</name></expr></argument>, <argument><name>value</name>=<expr><literal type="boolean">True</literal></expr></argument>)</argument_list></call></expr></lambda></expr></argument>)</argument_list></call></expr></lambda></expr></argument>,
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>sample</name> <operator>=</operator> <call><call><name>example</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name><name>a</name><operator>.</operator><name>b</name></name><argument_list>(<argument><expr><literal type="number">3.14</literal></expr></argument>)</argument_list></call></expr></lambda></expr></argument>)</argument_list></call><argument_list>(<argument><expr><call><name><name>a</name><operator>.</operator><name>c</name></name><argument_list>(<argument><expr><literal type="number">3</literal></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>call_one</name><argument_list>(
     <argument><name>description</name>=<expr><operator>(</operator>
         <literal type="string">"srcML infrastructure"</literal>
@@ -284,7 +284,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr></tuple> <operator>=</operator> <call><name>call_one</name><argument_list>(
     <argument><expr><operator>(</operator>
         <name>c</name>
@@ -295,7 +295,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>objects</name></expr></condition><block>:<block_content>
     <expr_stmt><expr><name><name>objects</name><index>[<expr><literal type="number">0</literal></expr>]</index></name> <operator>=</operator> <call><name>call_one</name><argument_list>(
         <argument><expr><lambda>lambda <parameter><name>a</name></parameter>: <expr><name>a</name> <ternary>if <condition><expr><name>b</name></expr></condition> <else>else <expr><call><name>call_two</name><argument_list>(<argument><expr><name>a</name></expr></argument>, <argument><expr><name>b</name></expr></argument>)</argument_list></call></expr></else></ternary></expr></lambda></expr></argument>,
@@ -304,7 +304,7 @@
 </block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sample</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>, <parameter><name>c</name></parameter>, <parameter><name>d</name></parameter>)</parameter_list><block>:<block_content>
     <if_stmt><if>if <condition><expr><name>a</name></expr></condition><block>:<block_content>
         <return>return <expr><call><name><name>a</name><operator>.</operator><name>call_one</name></name><argument_list>(
@@ -314,7 +314,7 @@
 </block_content></block></if></if_stmt></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <throw>raise <expr><name>ValueError</name></expr></throw>
 </block_content></block><catch>except <expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>e</name></expr></alias><block>:<block_content>
@@ -322,7 +322,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <throw>raise <expr><name>ValueError</name></expr></throw>
 </block_content></block><catch>except <alias><expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr>, <name>e</name></alias><block>:<block_content>
@@ -330,48 +330,48 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>a</name></expr> <range>in <expr><call><call><name>call_one</name><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call><argument_list>(<argument><expr><name>c</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for><specifier>async</specifier> for <control><expr><name>a</name></expr> <range>in <expr><call><call><name>call_one</name><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call><argument_list>(<argument><expr><name>c</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>call_parameter_annotation</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name><annotation>: <expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></annotation></parameter>, <parameter><name>c</name></parameter>)</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>call_parameter_init</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name><init>=<expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></init></parameter>, <parameter><name>c</name></parameter>)</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><call><name>example</name><argument_list>(<argument><name>x</name> = <expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">0</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></attribute>
 def <name>call_function</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><call><call><name>call_one</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>CallSuper</name><super_list>(<super><expr><name>A</name></expr></super>, <super><expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></super>, <super><expr><name>B</name></expr></super>)</super_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>call_comprehension</name> <operator>=</operator> <operator>(</operator><name>a</name> <comprehension><for>for <control><expr><name>a</name></expr> <range>in <expr><call><call><name>call_one</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call></expr></range></control></for></comprehension><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>call_comprehension_if</name> <operator>=</operator> <operator>(</operator>
     <name>a</name>
     <comprehension><for>for <control><expr><name>a</name></expr> <range>in <expr><call><call><name>call_one</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call></expr></range></control></for>
@@ -379,14 +379,14 @@ def <name>call_function</name><parameter_list>(<parameter><name>a</name></parame
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>call_list</name> <operator>=</operator> <array>[
     <expr><call><call><name>call_one</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call></expr>,
     <expr><name>c</name></expr>
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>call_lambda</name> <operator>=</operator> <call><name>example</name><argument_list>(<argument><expr><array>[
     <expr><call><name>dict</name><argument_list>(
         <argument><name>a</name>=<expr><lambda>lambda <parameter><name>b</name></parameter>: <expr><call><call><name>call_one</name><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call><argument_list>(<argument><expr><name>c</name></expr></argument>)</argument_list></call></expr></lambda></expr></argument>
@@ -395,7 +395,7 @@ def <name>call_function</name><parameter_list>(<parameter><name>a</name></parame
 ]</array></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>call_set</name> <operator>=</operator> <set>{
     <expr><name>a</name></expr>,
     <expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr>,
@@ -403,7 +403,7 @@ def <name>call_function</name><parameter_list>(<parameter><name>a</name></parame
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>call_dictionary</name> <operator>=</operator> <dictionary>{
     <expr><literal type="string">"a"</literal></expr>: <expr><name>a</name></expr>,
     <expr><literal type="string">"b"</literal></expr>: <expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr>,
@@ -411,7 +411,7 @@ def <name>call_function</name><parameter_list>(<parameter><name>a</name></parame
 }</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>call_tuple</name> <operator>=</operator> <tuple>(
     <expr><name>a</name></expr>,
     <expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr>,
@@ -419,31 +419,31 @@ def <name>call_function</name><parameter_list>(<parameter><name>a</name></parame
 )</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple><expr><name>no_paren</name></expr>, <expr><name>call_tuple</name></expr></tuple> <operator>=</operator> <tuple><expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr>, <expr><call><call><name>call_two</name><argument_list>(<argument><expr><literal type="number">3</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">4</literal></expr></argument>)</argument_list></call></expr></tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>call_ternary</name> <operator>=</operator> <operator>(</operator><name>a</name> <ternary>if <condition><expr><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></condition> <else>else <expr><call><call><name>call_two</name><argument_list>(<argument><expr><literal type="number">3</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">4</literal></expr></argument>)</argument_list></call></expr></else></ternary><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>call_op_paren</name> <operator>=</operator> <operator>(</operator><operator>(</operator><operator>(</operator><call><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><argument_list>(<argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call><operator>)</operator><operator>)</operator><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <call><name>call_one</name><argument_list>(<argument><expr><name>a</name></expr></argument>, <argument><expr><name>b</name></expr></argument>)</argument_list></call><index>[<expr><literal type="number">0</literal></expr>]</index></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <call><name>call_one</name><argument_list>(<argument><expr><name>a</name></expr></argument>, <argument><expr><name>b</name></expr></argument>)</argument_list></call><index>[<expr><literal type="number">0</literal></expr>]</index><index>[<expr><literal type="number">1</literal></expr>]</index></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <call><name>call_one</name><argument_list>(<argument><expr><name>a</name></expr></argument>, <argument><expr><name>b</name></expr></argument>)</argument_list></call><index>[<expr><literal type="number">0</literal></expr>]</index><operator>.</operator><call><name>call_two</name><argument_list>(<argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>)</argument_list></call><index>[<expr><literal type="number">1</literal></expr>]</index></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <call><name>call_one</name><argument_list>(<argument><expr><call><name>call_two</name><argument_list>(<argument><expr><name>a</name></expr></argument>, <argument><expr><name>b</name></expr></argument>)</argument_list></call><index>[<expr><literal type="number">0</literal></expr>]</index></expr></argument>, <argument><expr><name>c</name></expr></argument>)</argument_list></call><index>[<expr><literal type="number">0</literal></expr>]</index></expr></expr_stmt>
 </unit>
 

--- a/test/parser/testsuite/case_py.py.xml
+++ b/test/parser/testsuite/case_py.py.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="case">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><name>x</name></expr></condition><block>:<block_content>
     <case>case <expr><literal type="number">3</literal></expr><block>:<block_content>
         <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"three"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></case></block_content></block></switch>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><name>word</name></expr></condition><block>:<block_content>
     <case>case <expr><literal type="string">"one"</literal></expr><block>:<block_content>
         <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
@@ -19,7 +19,7 @@
 </block_content></block></case></block_content></block></switch>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><name>truth</name></expr></condition><block>:<block_content>
     <case>case <expr><literal type="boolean">True</literal></expr><block>:<block_content>
         <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Yes"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
@@ -28,7 +28,7 @@
 </block_content></block></case></block_content></block></switch>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><name>a</name></expr></condition><block>:<block_content>
     <case>case <expr><literal type="string">"a"</literal></expr><block>:<block_content>
         <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"a"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
@@ -38,7 +38,7 @@
 </block_content></block></if></if_stmt></block_content></block></case></block_content></block></switch>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><name>a</name></expr></condition><block>:<block_content>
     <case>case <expr><literal type="string">"a"</literal></expr><block>:<block_content>
         <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"a"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>

--- a/test/parser/testsuite/catch_py.py.xml
+++ b/test/parser/testsuite/catch_py.py.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="catch">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except<block>:<block_content>
@@ -9,7 +9,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content>
@@ -17,7 +17,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <expr><name>ZeroDivisionError</name></expr> <alias>as <expr><name>e</name></expr></alias><block>:<block_content>
@@ -25,7 +25,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <expr><name>ValueError</name></expr> <alias>as <expr><name>e</name></expr></alias><block>:<block_content>
@@ -37,7 +37,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except* <expr><name>NameError</name></expr> <alias>as <expr><name>e</name></expr></alias><block>:<block_content>
@@ -47,7 +47,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <expr><tuple><expr><name>CustomError</name></expr>, <expr><tuple>(<expr><name>x</name></expr>, <expr><name>y</name></expr>)</tuple></expr></tuple></expr><block>:<block_content>

--- a/test/parser/testsuite/class_py.py.xml
+++ b/test/parser/testsuite/class_py.py.xml
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="class">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Truck</name><block>:<block_content>
     <function>def <name>__init__</name><parameter_list>(<parameter><name>self</name></parameter>)</parameter_list><block>:<block_content>
         <pass>pass</pass>
 </block_content></block></function></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Nothing</name><super_list>()</super_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>EV</name><super_list>(<super><expr><name>Car</name></expr></super>)</super_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>ETruck</name><super_list>(<super><expr><name>EV</name></expr></super>, <super><expr><name>Truck</name></expr></super>)</super_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Example</name><super_list>(<super><expr><name>a</name></expr></super>, <super><expr><name>b</name></expr></super>, <super><expr><name>metaclass</name><operator>=</operator><name>Sample</name></expr></super>)</super_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Example</name><super_list>(
     <super><expr><call><name>namedtuple</name><argument_list>(
         <argument><expr><literal type="string">"Example"</literal></expr></argument>, <argument><expr><tuple>(<expr><literal type="string">"a"</literal></expr>, <expr><literal type="string">"b"</literal></expr>, <expr><literal type="string">"c"</literal></expr>)</tuple></expr></argument>
@@ -48,26 +48,26 @@
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Box</name><super_list>(<super><expr><name><name>Generic</name><index>[<expr><name>T</name></expr>]</index></name></expr></super>)</super_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Box</name><super_list>(<super><expr><name><name>Generic</name><index>[<expr><name>T</name></expr>]</index></name></expr></super>, <super><expr><name><name>Generic</name><index>[<expr><name>T</name></expr>]</index></name></expr></super>)</super_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class><attribute>@<expr><name>unique</name></expr></attribute>
 class <name>License</name><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class><attribute>@<expr><name>Operator</name></expr></attribute>
 <attribute>@<expr><call><name>GetType</name><argument_list>()</argument_list></call></expr></attribute>
 class <name>new_op</name><block>:<block_content>
@@ -75,7 +75,7 @@ class <name>new_op</name><block>:<block_content>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class><attribute>@<expr><name>unique</name></expr></attribute>
 <attribute>@<expr><call><name>GetType</name><argument_list>()</argument_list></call></expr></attribute>
 class <name>All</name><super_list>(<super><expr><name>Nothing</name></expr></super>,<super><expr><name>new_op</name></expr></super>,<super><expr><call><name>GetParent</name><argument_list>()</argument_list></call></expr></super>)</super_list><block>:<block_content>
@@ -83,33 +83,33 @@ class <name>All</name><super_list>(<super><expr><name>Nothing</name></expr></sup
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name><name>list</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list></name><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name><name>Box</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list></name><super_list>(<super><expr><name><name>Generic</name><index>[<expr><name>T</name></expr>]</index></name></expr></super>)</super_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Player</name><block>:<block_content> <expr_stmt><expr><name>speed</name> <operator>=</operator> <literal type="number">10</literal></expr></expr_stmt></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Player</name><block>:<block_content> <expr_stmt><expr><name>a</name> <operator>=</operator> <literal type="number">10</literal></expr>;</expr_stmt> <expr_stmt><expr><name>b</name> <operator>=</operator> <literal type="number">20</literal></expr></expr_stmt></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Player</name><block>:<block_content>
     <function>def <name>run</name><parameter_list>(<parameter><name>self</name></parameter>)</parameter_list><block>:<block_content> <return>return <expr><literal type="number">10</literal></expr></return></block_content></block></function>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Player</name><block>:<block_content>
     <function>def <name>run</name><parameter_list>(<parameter><name>self</name></parameter>)</parameter_list><block>:<block_content> <pass>pass</pass></block_content></block></function>
 

--- a/test/parser/testsuite/comment_py.py.xml
+++ b/test/parser/testsuite/comment_py.py.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="comment">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <comment type="line">#</comment>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <comment type="line">#a</comment>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <comment type="line">#abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&amp;*()`-=[]\;',./~_+{}|:"&lt;&gt;?</comment>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <comment type="hashbang">#!/usr/bin/env python3</comment>
 </unit>
 

--- a/test/parser/testsuite/comprehension_py.py.xml
+++ b/test/parser/testsuite/comprehension_py.py.xml
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="comprehension">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>(</operator><name>x</name> <comprehension><for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>(</operator><name>x</name> <comprehension><for><specifier>async</specifier> for <control><expr><name>x</name></expr> <range>in <expr><call><name>async_range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><name>x</name></expr> <comprehension><for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><name>x</name></expr> <comprehension><for><specifier>async</specifier> for <control><expr><name>x</name></expr> <range>in <expr><call><name>async_range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{<expr><name>x</name></expr> <comprehension><for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>}</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{<expr><name>x</name></expr> <comprehension><for><specifier>async</specifier> for <control><expr><name>x</name></expr> <range>in <expr><call><name>async_range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>}</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{<expr><name>x</name></expr>:<expr><name>x</name><operator>+</operator><literal type="number">1</literal></expr> <comprehension><for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{<expr><name>x</name></expr>:<expr><name>x</name><operator>+</operator><literal type="number">1</literal></expr> <comprehension><for><specifier>async</specifier> for <control><expr><name>x</name></expr> <range>in <expr><call><name>async_range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>=</operator> <array>[<expr><name>x</name></expr> <comprehension><for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><name>val</name> <operator>*</operator> <literal type="number">2</literal></expr> <comprehension><for>for <control><expr><name>val</name></expr> <range>in <expr><name>array</name></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><call><name><name>val</name><operator>.</operator><name>example</name></name><argument_list>(<argument><expr><name>a</name></expr></argument>, <argument><expr><name>b</name></expr></argument>)</argument_list></call> <operator>*</operator> <literal type="number">2</literal></expr> <comprehension><for>for <control><expr><tuple><expr><name>a</name></expr>,<expr><name>b</name></expr></tuple></expr> <range>in <expr><name>array</name></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><name>user</name> <operator>+</operator> <literal type="string">' '</literal> <operator>+</operator> <name>status</name></expr> <comprehension><for>for <control><expr><tuple><expr><name>user</name></expr>, <expr><name>status</name></expr></tuple></expr> <range>in <expr><call><name><name>users</name><operator>.</operator><name>items</name></name><argument_list>()</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><name>val</name></expr> <comprehension><for>for <control><expr><name>val</name></expr> <range>in <expr><name>a</name></expr></range></control></for> <if>if <condition><expr><name>val</name> <operator>%</operator> <literal type="number">2</literal> <operator>==</operator> <literal type="number">0</literal></expr></condition></if></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><name>val</name></expr> <comprehension><for>for <control><expr><name>val</name></expr> <range>in <expr><name>a</name></expr></range></control></for> <if>if <condition><expr><name>val</name> <operator>%</operator> <literal type="number">2</literal> <operator>==</operator> <literal type="number">0</literal></expr></condition></if> <if>if <condition><expr><name>val</name> <operator>%</operator> <literal type="number">3</literal> <operator>==</operator> <literal type="number">0</literal></expr></condition></if></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><name>x</name></expr> <comprehension><for>for <control><expr><name>x</name></expr> <range>in <expr><array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><name>a</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">100</literal></expr></argument>)</argument_list></call></expr></range></control></for> <if>if <condition><expr><name>a</name> <operator>&lt;</operator> <literal type="number">50</literal></expr></condition></if></comprehension>]</array></expr></range></control></for> <if>if <condition><expr><name>x</name> <operator>%</operator> <literal type="number">2</literal> <operator>==</operator> <literal type="number">0</literal></expr></condition></if></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><operator>(</operator><name>val</name> <operator>*</operator> <literal type="number">2</literal> <comprehension><for>for <control><expr><name>val</name></expr> <range>in <expr><name>array</name></expr></range></control></for></comprehension><operator>)</operator></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>options</name> <operator>=</operator> <operator>(</operator>
     <name>a</name>
     <comprehension><for>for <control><expr><tuple><expr><name>_</name></expr>, <expr><name>a</name></expr>, <expr><name>_</name></expr></tuple></expr> <range>in <expr><call><name>example</name><argument_list>(
@@ -74,131 +74,131 @@
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><literal type="boolean">True</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>next</name><argument_list>(<argument><expr><name>a</name></expr> <comprehension><for>for <control><expr><name>a</name></expr> <range>in <expr><name>b</name></expr></range></control></for> <if>if <condition><expr><literal type="boolean">True</literal></expr></condition></if></comprehension></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><literal type="boolean">True</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>next</name><argument_list>(<argument><expr><name>a</name></expr> <comprehension><for>for <control><expr><name>a</name></expr> <range>in <expr><name>b</name></expr></range></control></for> <if>if <condition><expr><literal type="boolean">True</literal></expr></condition></if> <if>if <condition><expr><literal type="boolean">True</literal></expr></condition></if></comprehension></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>example</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><name>b</name></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>example</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><operator>(</operator><name>b</name><operator>)</operator></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>example</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><operator>(</operator><operator>(</operator><operator>(</operator><name>b</name><operator>)</operator><operator>)</operator><operator>)</operator></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>example</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><tuple><expr><name>b</name></expr>, <expr><name>c</name></expr></tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>d</name></expr></argument>, <argument><expr><name>e</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>example</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><tuple>(<expr><name>b</name></expr>, <expr><name>c</name></expr>)</tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>d</name></expr></argument>, <argument><expr><name>e</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>example</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><tuple>(<expr><operator>(</operator><operator>(</operator><name>b</name><operator>)</operator><operator>)</operator></expr>, <expr><operator>(</operator><operator>(</operator><name>c</name><operator>)</operator><operator>)</operator></expr>)</tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>d</name></expr></argument>, <argument><expr><name>e</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>example</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><tuple>(<expr><operator>(</operator><tuple>(<expr><name>b</name></expr>, <expr><name>c</name></expr>)</tuple><operator>)</operator></expr>, <expr><name>d</name></expr>)</tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>e</name></expr></argument>, <argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>example</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><tuple><expr><name>b</name></expr>, <expr><tuple>(<expr><name>c</name></expr>, <expr><tuple>(<expr><name>d</name></expr>, <expr><name>e</name></expr>)</tuple></expr>)</tuple></expr></tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>f</name></expr></argument>, <argument><expr><name>g</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>example</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><tuple><expr><operator>(</operator><name>b</name><operator>)</operator></expr>, <expr><tuple>(<expr><operator>(</operator><name>c</name><operator>)</operator></expr>, <expr><tuple>(<expr><operator>(</operator><name>d</name><operator>)</operator></expr>, <expr><operator>(</operator><name>e</name><operator>)</operator></expr>)</tuple></expr>)</tuple></expr></tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>f</name></expr></argument>, <argument><expr><name>g</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><array>[<expr><name>b</name></expr>]</array></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>c</name></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><array>[<expr><name>b</name></expr>, <expr><name>c</name></expr>]</array></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><array>[<expr><operator>(</operator><name>b</name><operator>)</operator></expr>]</array></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>c</name></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><array>[<expr><operator>(</operator><name>b</name><operator>)</operator></expr>, <expr><operator>(</operator><name>c</name><operator>)</operator></expr>]</array></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><operator>(</operator><array>[<expr><name>b</name></expr>, <expr><name>c</name></expr>]</array><operator>)</operator></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><array>[<expr><tuple>(<expr><name>b</name></expr>, <expr><name>c</name></expr>)</tuple></expr>, <expr><tuple>(<expr><name>d</name></expr>, <expr><name>e</name></expr>)</tuple></expr>]</array></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><operator>(</operator><array>[<expr><tuple>(<expr><name>b</name></expr>, <expr><name>c</name></expr>)</tuple></expr>, <expr><tuple>(<expr><name>d</name></expr>, <expr><name>e</name></expr>)</tuple></expr>]</array><operator>)</operator></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><array>[<expr><array>[<expr><name>b</name></expr>, <expr><name>c</name></expr>]</array></expr>, <expr><array>[<expr><name>d</name></expr>, <expr><name>e</name></expr>]</array></expr>]</array></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><tuple>(<expr><array>[<expr><array>[<expr><name>b</name></expr>, <expr><name>c</name></expr>]</array></expr>, <expr><array>[<expr><name>d</name></expr>, <expr><name>e</name></expr>]</array></expr>]</array></expr>, <expr><array>[<expr><array>[<expr><name>f</name></expr>, <expr><name>g</name></expr>]</array></expr>, <expr><array>[<expr><name>h</name></expr>, <expr><name>i</name></expr>]</array></expr>]</array></expr>)</tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>j</name></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>types</name> <operator>=</operator> <set>{ <expr><call><name>type</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr> <comprehension><for>for <control><expr><operator>*</operator><name>_</name></expr> <range>in <expr><name>a</name></expr></range></control></for></comprehension> }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>types</name> <operator>=</operator> <set>{ <expr><call><name>type</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr> <comprehension><for>for <control><expr><operator>(</operator><operator>*</operator><name>_</name><operator>)</operator></expr> <range>in <expr><name>a</name></expr></range></control></for></comprehension> }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>types</name> <operator>=</operator> <set>{ <expr><call><name>type</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr> <comprehension><for>for <control><expr><tuple><expr><name>a</name></expr>, <expr><operator>*</operator><name>_</name></expr></tuple></expr> <range>in <expr><name>b</name></expr></range></control></for></comprehension> }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>types</name> <operator>=</operator> <set>{ <expr><call><name>type</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr> <comprehension><for>for <control><expr><tuple>(<expr><operator>*</operator><name>_</name></expr>, <expr><name>a</name></expr>)</tuple></expr> <range>in <expr><name>b</name></expr></range></control></for></comprehension> }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>types</name> <operator>=</operator> <set>{ <expr><call><name>type</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr> <comprehension><for>for <control><expr><array>[<expr><operator>*</operator><name>_</name></expr>, <expr><name>a</name></expr>]</array></expr> <range>in <expr><name>b</name></expr></range></control></for></comprehension> }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>types</name> <operator>=</operator> <set>{ <expr><call><name>type</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr> <comprehension><for>for <control><expr><operator>**</operator><name>_</name></expr> <range>in <expr><name>a</name></expr></range></control></for></comprehension> }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>types</name> <operator>=</operator> <set>{ <expr><call><name>type</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr> <comprehension><for>for <control><expr><operator>(</operator><operator>**</operator><name>_</name><operator>)</operator></expr> <range>in <expr><name>a</name></expr></range></control></for></comprehension> }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>types</name> <operator>=</operator> <set>{ <expr><call><name>type</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr> <comprehension><for>for <control><expr><tuple><expr><name>a</name></expr>, <expr><operator>**</operator><name>_</name></expr></tuple></expr> <range>in <expr><name>b</name></expr></range></control></for></comprehension> }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>types</name> <operator>=</operator> <set>{ <expr><call><name>type</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr> <comprehension><for>for <control><expr><tuple>(<expr><operator>**</operator><name>_</name></expr>, <expr><name>a</name></expr>)</tuple></expr> <range>in <expr><name>b</name></expr></range></control></for></comprehension> }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>types</name> <operator>=</operator> <set>{ <expr><call><name>type</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr> <comprehension><for>for <control><expr><array>[<expr><operator>**</operator><name>_</name></expr>, <expr><name>a</name></expr>]</array></expr> <range>in <expr><name>b</name></expr></range></control></for></comprehension> }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><name>a</name></expr> <comprehension><for>for <control><expr><operator>(</operator><name>b</name> <ternary>if <condition><expr><name>c</name></expr></condition> <else>else <expr><name>d</name></expr></else></ternary><operator>)</operator><index>[<expr><literal type="number">0</literal></expr>]</index></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 

--- a/test/parser/testsuite/condition_py.py.xml
+++ b/test/parser/testsuite/condition_py.py.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="condition">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><literal type="boolean">True</literal></expr></condition></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">"even"</literal> <ternary>if <condition><expr><name>x</name> <operator>%</operator> <literal type="number">2</literal> <operator>==</operator> <literal type="number">0</literal></expr></condition> <else>else <expr><literal type="string">"odd"</literal></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><literal type="boolean">False</literal></expr></condition><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></while>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><literal type="boolean">True</literal></expr></condition><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></if><if type="elseif">elif <condition><expr><literal type="boolean">False</literal></expr></condition><block>:<block_content>
@@ -23,7 +23,7 @@
 </block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><name>value</name></expr></condition><block>:<block_content>
     <case>case <expr><literal type="number">1</literal></expr><block>:<block_content>
         <pass>pass</pass>

--- a/test/parser/testsuite/continue_py.py.xml
+++ b/test/parser/testsuite/continue_py.py.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="continue">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <continue>continue</continue>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><name>loop</name></expr></condition><block>:<block_content>
     <continue>continue</continue>
 </block_content></block></while>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <if_stmt><if>if <condition><expr><name>x</name> <operator>!=</operator> <literal type="number">3</literal></expr></condition><block>:<block_content>
         <continue>continue</continue>

--- a/test/parser/testsuite/delete_py.py.xml
+++ b/test/parser/testsuite/delete_py.py.xml
@@ -1,10 +1,10 @@
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="delete">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <delete>del <name>x</name></delete>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <delete>del <name>x</name>, <name>y</name></delete>
 </unit>
 

--- a/test/parser/testsuite/dictionary_py.py.xml
+++ b/test/parser/testsuite/dictionary_py.py.xml
@@ -1,43 +1,43 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="dictionary">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{<expr><literal type="string">'1'</literal></expr>:<expr><literal type="number">1</literal></expr>}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{<expr><literal type="string">'1'</literal></expr>:<expr><literal type="number">1</literal></expr>, <expr><literal type="string">'2'</literal></expr>:<expr><literal type="number">2</literal></expr>}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{<expr><literal type="string">'1'</literal></expr>:<expr><literal type="number">1</literal></expr>, <expr><literal type="string">'2'</literal></expr>:<expr><literal type="number">2</literal></expr>, <expr><literal type="string">'3'</literal></expr>:<expr><literal type="number">3</literal></expr>}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{<expr><literal type="string">'one'</literal></expr>:<expr><literal type="number">1</literal></expr>}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>=</operator> <dictionary>{<expr><literal type="number">1.0</literal></expr>:<expr><literal type="number">1</literal></expr>}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{<expr><name>x</name></expr>:<expr><call><name>str</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr> <comprehension><for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{<expr><literal type="string">'a'</literal></expr>:<expr><dictionary>{}</dictionary></expr>}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{<expr><literal type="string">'a'</literal></expr>:<expr><dictionary>{<expr><literal type="number">1</literal></expr>:<expr><literal type="string">'1'</literal></expr>}</dictionary></expr>, <expr><literal type="string">'b'</literal></expr>:<expr><dictionary>{<expr><literal type="number">2</literal></expr>:<expr><literal type="string">'2'</literal></expr>}</dictionary></expr>, <expr><literal type="string">'c'</literal></expr>:<expr><dictionary>{<expr><literal type="number">3</literal></expr>:<expr><literal type="string">'3'</literal></expr>}</dictionary></expr>, <expr><literal type="string">'d'</literal></expr>:<expr><dictionary>{<expr><literal type="number">4</literal></expr>:<expr><literal type="string">'4'</literal></expr>}</dictionary></expr>}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{<expr><literal type="number">1</literal></expr> : <expr><set>{<expr><literal type="number">2</literal></expr>}</set></expr>}</dictionary></expr></expr_stmt>
 </unit>
 

--- a/test/parser/testsuite/else_py.py.xml
+++ b/test/parser/testsuite/else_py.py.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="else">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">"even"</literal> <ternary>if <condition><expr><name>x</name> <operator>%</operator> <literal type="number">2</literal> <operator>==</operator> <literal type="number">0</literal></expr></condition> <else>else <expr><literal type="string">"odd"</literal></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><name>x</name> <operator>&gt;=</operator> <literal type="number">0</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block><else>else<block>:<block_content>
@@ -13,7 +13,7 @@
 </block_content></block></else></while>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block><else>else<block>:<block_content>
@@ -21,7 +21,7 @@
 </block_content></block></else></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>val</name> <operator>in</operator> <name>arr</name></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"In"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></if><else>else<block>:<block_content>
@@ -29,7 +29,7 @@
 </block_content></block></else></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <pass>pass</pass>
 </block_content></block><catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content>

--- a/test/parser/testsuite/finally_py.py.xml
+++ b/test/parser/testsuite/finally_py.py.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="finally">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Valid"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block><finally>finally<block>:<block_content>
@@ -9,7 +9,7 @@
 </block_content></block></finally></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block><catch>except<block>:<block_content>

--- a/test/parser/testsuite/for_py.py.xml
+++ b/test/parser/testsuite/for_py.py.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="for">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block><else>else<block>:<block_content>
@@ -15,13 +15,13 @@
 </block_content></block></else></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for><specifier>async</specifier> for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <expr_stmt><expr><operator>await</operator> <call><name>do_thing</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for><specifier>async</specifier> for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <expr_stmt><expr><operator>await</operator> <call><name>do_thing</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block><else>else<block>:<block_content>
@@ -29,207 +29,207 @@
 </block_content></block></else></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block>
 <else>else<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"srcML"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"\n"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block>
 <else>else<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"srcML"</literal></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"infrastructure"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for><specifier>async</specifier> for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for><specifier>async</specifier> for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"\n"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for><specifier>async</specifier> for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block>
 <else>else<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"srcML"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for><specifier>async</specifier> for <control><expr><name>x</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"\n"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block>
 <else>else<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"srcML"</literal></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"infrastructure"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>a</name></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>e</name></expr></argument>, <argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><operator>(</operator><name>a</name><operator>)</operator></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>e</name></expr></argument>, <argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><operator>(</operator><operator>(</operator><operator>(</operator><name>a</name><operator>)</operator><operator>)</operator><operator>)</operator></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>e</name></expr></argument>, <argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr></tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>e</name></expr></argument>, <argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>e</name></expr></argument>, <argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><tuple>(<expr><operator>(</operator><operator>(</operator><name>a</name><operator>)</operator><operator>)</operator></expr>, <expr><operator>(</operator><operator>(</operator><name>b</name><operator>)</operator><operator>)</operator></expr>)</tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>e</name></expr></argument>, <argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><tuple>(<expr><operator>(</operator><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple><operator>)</operator></expr>, <expr><name>c</name></expr>)</tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>d</name></expr></argument>, <argument><expr><name>e</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><tuple><expr><name>a</name></expr>, <expr><tuple>(<expr><name>b</name></expr>, <expr><tuple>(<expr><name>c</name></expr>, <expr><name>d</name></expr>)</tuple></expr>)</tuple></expr></tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>e</name></expr></argument>, <argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><tuple><expr><operator>(</operator><name>a</name><operator>)</operator></expr>, <expr><tuple>(<expr><operator>(</operator><name>b</name><operator>)</operator></expr>, <expr><tuple>(<expr><operator>(</operator><name>c</name><operator>)</operator></expr>, <expr><operator>(</operator><name>d</name><operator>)</operator></expr>)</tuple></expr>)</tuple></expr></tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><call><name>zip</name><argument_list>(<argument><expr><name>e</name></expr></argument>, <argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><array>[<expr><name>b</name></expr>]</array></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>c</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><array>[<expr><name>b</name></expr>, <expr><name>c</name></expr>]</array></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><array>[<expr><operator>(</operator><name>b</name><operator>)</operator></expr>]</array></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>c</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><array>[<expr><operator>(</operator><name>b</name><operator>)</operator></expr>, <expr><operator>(</operator><name>c</name><operator>)</operator></expr>]</array></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><operator>(</operator><array>[<expr><name>b</name></expr>, <expr><name>c</name></expr>]</array><operator>)</operator></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><array>[<expr><tuple>(<expr><name>b</name></expr>, <expr><name>c</name></expr>)</tuple></expr>, <expr><tuple>(<expr><name>d</name></expr>, <expr><name>e</name></expr>)</tuple></expr>]</array></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><operator>(</operator><array>[<expr><tuple>(<expr><name>b</name></expr>, <expr><name>c</name></expr>)</tuple></expr>, <expr><tuple>(<expr><name>d</name></expr>, <expr><name>e</name></expr>)</tuple></expr>]</array><operator>)</operator></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><array>[<expr><array>[<expr><name>b</name></expr>, <expr><name>c</name></expr>]</array></expr>, <expr><array>[<expr><name>d</name></expr>, <expr><name>e</name></expr>]</array></expr>]</array></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>f</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><tuple>(<expr><array>[<expr><array>[<expr><name>b</name></expr>, <expr><name>c</name></expr>]</array></expr>, <expr><array>[<expr><name>d</name></expr>, <expr><name>e</name></expr>]</array></expr>]</array></expr>, <expr><array>[<expr><array>[<expr><name>f</name></expr>, <expr><name>g</name></expr>]</array></expr>, <expr><array>[<expr><name>h</name></expr>, <expr><name>i</name></expr>]</array></expr>]</array></expr>)</tuple></expr> <range>in <expr><call><name>enumerate</name><argument_list>(<argument><expr><name>j</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><operator>*</operator><name>_</name></expr> <range>in <expr><name>a</name></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><operator>(</operator><operator>*</operator><name>_</name><operator>)</operator></expr> <range>in <expr><name>a</name></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><tuple><expr><name>a</name></expr>, <expr><operator>*</operator><name>_</name></expr></tuple></expr> <range>in <expr><name>b</name></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><tuple>(<expr><operator>*</operator><name>_</name></expr>, <expr><name>a</name></expr>)</tuple></expr> <range>in <expr><name>b</name></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><array>[<expr><operator>*</operator><name>_</name></expr>, <expr><name>a</name></expr>]</array></expr> <range>in <expr><name>b</name></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><operator>**</operator><name>_</name></expr> <range>in <expr><name>a</name></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><operator>(</operator><operator>**</operator><name>_</name><operator>)</operator></expr> <range>in <expr><name>a</name></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><tuple><expr><name>a</name></expr>, <expr><operator>**</operator><name>_</name></expr></tuple></expr> <range>in <expr><name>b</name></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><tuple>(<expr><operator>**</operator><name>_</name></expr>, <expr><name>a</name></expr>)</tuple></expr> <range>in <expr><name>b</name></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><array>[<expr><operator>**</operator><name>_</name></expr>, <expr><name>a</name></expr>]</array></expr> <range>in <expr><name>b</name></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><operator>(</operator><name>a</name> <ternary>if <condition><expr><name>b</name></expr></condition> <else>else <expr><name>c</name></expr></else></ternary><operator>)</operator><index>[<expr><literal type="number">0</literal></expr>]</index></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></for>

--- a/test/parser/testsuite/formatting_py.py.xml
+++ b/test/parser/testsuite/formatting_py.py.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="formatting">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Sample</name><block>:<block_content> <comment type="line">#CommentA</comment>
                 <comment type="line"># Comment B</comment>
     <function>def <name>method</name><parameter_list>(<parameter><name>self</name></parameter>)</parameter_list><block>:<block_content> <comment type="line"># Comment C</comment>
@@ -10,14 +10,14 @@
 </block_content></block></function></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Sample</name><block>:<block_content><comment type="line"># Comment A</comment>
     <function>def <name>method</name><parameter_list>(<parameter><name>self</name></parameter>)</parameter_list><block>:<block_content><comment type="line"># Comment B</comment>
         <pass>pass</pass><comment type="line">#Comment C</comment>
 </block_content></block></function></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Sample</name><block>:<block_content> <comment type="hashbang">#! CommentA</comment>
                 <comment type="hashbang">#! Comment B</comment>
     <function>def <name>method</name><parameter_list>(<parameter><name>self</name></parameter>)</parameter_list><block>:<block_content> <comment type="hashbang">#! Comment C</comment>
@@ -26,30 +26,30 @@
 </block_content></block></function></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Sample</name><block>:<block_content><comment type="hashbang">#! Comment A</comment>
     <function>def <name>method</name><parameter_list>(<parameter><name>self</name></parameter>)</parameter_list><block>:<block_content><comment type="hashbang">#! Comment B</comment>
         <pass>pass</pass><comment type="hashbang">#! Comment C</comment>
 </block_content></block></function></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>a</name> <operator>=</operator> <literal type="number">0</literal></expr></expr_stmt><comment type="line"># Comment Z</comment>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>a</name> <operator>=</operator> <literal type="number">0</literal></expr></expr_stmt> <comment type="line"># Comment Z</comment>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>a</name> <operator>=</operator> <literal type="number">0</literal></expr></expr_stmt><comment type="hashbang">#! Comment Z</comment>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>a</name> <operator>=</operator> <literal type="number">0</literal></expr></expr_stmt> <comment type="hashbang">#! Comment Z</comment>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Sample</name> <block>:<block_content>   
         
     <function>def <name>method</name><parameter_list>(<parameter><name>self</name></parameter>)</parameter_list> <block>:<block_content>  
@@ -57,24 +57,24 @@
 </block_content></block></function></block_content></block></class>     
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>__name__</name> <operator>==</operator> <literal type="string">"__main__"</literal></expr></condition><block>:<block_content>
   <expr_stmt><expr><call><name>main</name><argument_list>()</argument_list></call></expr></expr_stmt>
 </block_content></block></if></if_stmt>  
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>__name__</name> <operator>==</operator> <literal type="string">"__main__"</literal></expr></condition><block>:<block_content>
   <if_stmt><if>if <condition><expr><literal type="boolean">True</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>main</name><argument_list>()</argument_list></call></expr></expr_stmt>
 </block_content></block></if></if_stmt></block_content></block></if></if_stmt>  
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>a</name> <operator>=</operator> <literal type="number">0</literal></expr></expr_stmt>    
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 
 
 
@@ -84,7 +84,7 @@
 
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 
 
 

--- a/test/parser/testsuite/function_py.py.xml
+++ b/test/parser/testsuite/function_py.py.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="function">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>do_nothing</name><parameter_list>()</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><name>do_nothing</name></expr></attribute>
 def <name>func</name><parameter_list>()</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><name>print</name></expr></attribute>
 <attribute>@<expr><name>exec</name></expr></attribute>
 def <name>func</name><parameter_list>()</parameter_list><block>:<block_content>
@@ -22,66 +22,66 @@ def <name>func</name><parameter_list>()</parameter_list><block>:<block_content>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><specifier>async</specifier> def <name>async_loop</name><parameter_list>()</parameter_list><block>:<block_content>
     <expr_stmt><expr><operator>await</operator> <call><name>start_loop</name><argument_list>()</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>printf</name><parameter_list>(<parameter><name>x</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">f"{x}"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>get_time_str</name><parameter_list>()</parameter_list> <annotation>-&gt; <expr><name>str</name></expr></annotation><block>:<block_content>
     <return>return <expr><call><name>str</name><argument_list>(<argument><expr><call><name><name>time</name><operator>.</operator><name>time</name></name><argument_list>()</argument_list></call></expr></argument>)</argument_list></call></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><name>print</name></expr></attribute>
 <specifier>async</specifier> def <name>async_printf</name><parameter_list>(<parameter><name>content</name></parameter>, <parameter><name>format_str</name></parameter>)</parameter_list> <annotation>-&gt; <expr><literal type="null">None</literal></expr></annotation><block>:<block_content>
     <expr_stmt><expr><operator>await</operator> <call><name>print</name><argument_list>(<argument><expr><call><name><name>format_str</name><operator>.</operator><name>format</name></name><argument_list>(<argument><expr><name>content</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>foo</name><parameter_list>()</parameter_list><block>:<block_content> <return>return <expr><literal type="string">"foo"</literal></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>foo</name><parameter_list>()</parameter_list><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"foo"</literal></expr></argument>)</argument_list></call></expr>;</expr_stmt> <return>return <expr><literal type="string">"foo"</literal></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><specifier>async</specifier> def <name>async_loop</name><parameter_list>()</parameter_list><block>:<block_content> <expr_stmt><expr><operator>await</operator> <call><name>start_loop</name><argument_list>()</argument_list></call></expr></expr_stmt></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><specifier>async</specifier> def <name>async_loop</name><parameter_list>()</parameter_list><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"srcML"</literal></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><operator>await</operator> <call><name>start_loop</name><argument_list>()</argument_list></call></expr></expr_stmt></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>test_lambda</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>, <parameter><name>func</name><init>=<expr><lambda>lambda <parameter><name>c</name></parameter>, <parameter type="args">*<name>d</name></parameter>, <parameter type="kwargs">**<name>e</name></parameter>: <expr><name>c</name></expr></lambda></expr></init></parameter>)</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>test_lambda</name><parameter_list>(<parameter><name>func</name><init>=<expr><lambda>lambda <parameter><name>a</name></parameter>, <parameter type="args">*<name>b</name></parameter>, <parameter type="kwargs">**<name>c</name></parameter>: <expr><name>a</name></expr></lambda></expr></init></parameter>, <parameter><name>d</name><init>=<expr><literal type="number">10</literal></expr></init></parameter>)</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>example</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><call><name>b</name><argument_list>(<argument><expr><name>c</name></expr></argument>, <argument><expr><operator>*</operator><name>d</name></expr></argument>, <argument><name>e</name>=<expr><name>f</name></expr></argument>)</argument_list></call></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>example_one</name><parameter_list>(<parameter><name>self</name></parameter>)</parameter_list><block>:<block_content>
     <function>def <name>example_two</name><parameter_list>(
         <parameter><name>a</name><annotation>: <expr><name>b</name> <operator>+</operator> <name>c</name></expr></annotation></parameter>,
@@ -92,7 +92,7 @@ def <name>func</name><parameter_list>()</parameter_list><block>:<block_content>
 </block_content></block></function></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><attribute>@<expr><call><name>async</name><argument_list>(<argument><expr><name>async</name><operator>=</operator><literal type="boolean">True</literal></expr></argument>)</argument_list></call></expr></attribute>
 def <name>example_one</name><parameter_list>()</parameter_list><block>:<block_content>
     <return>return <expr><literal type="boolean">True</literal></expr></return>

--- a/test/parser/testsuite/global_py.py.xml
+++ b/test/parser/testsuite/global_py.py.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="global">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <global>global <name>var</name></global>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>myfunc</name><parameter_list>()</parameter_list><block>:<block_content>
     <global>global <name>x</name></global>
 </block_content></block></function>

--- a/test/parser/testsuite/if_py.py.xml
+++ b/test/parser/testsuite/if_py.py.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="if">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>x</name> <operator>&lt;</operator> <literal type="number">10</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>x</name> <operator>&gt;</operator> <literal type="number">10</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Large"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></if><else>else<block>:<block_content>
@@ -15,7 +15,7 @@
 </block_content></block></else></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>x</name> <operator>&gt;</operator> <literal type="number">10</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Large"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></if><if type="elseif">elif <condition><expr><name>x</name> <operator>&gt;</operator> <literal type="number">10</literal></expr></condition><block>:<block_content>
@@ -23,7 +23,7 @@
 </block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>x</name> <operator>&gt;</operator> <literal type="number">10</literal></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Large"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></if><if type="elseif">elif <condition><expr><name>x</name> <operator>&gt;</operator> <literal type="number">10</literal></expr></condition><block>:<block_content>
@@ -33,7 +33,7 @@
 </block_content></block></else></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><operator>not</operator> <call><name>int_check</name><argument_list>(<argument><expr><name>value</name></expr></argument>)</argument_list></call></expr></condition><block>:<block_content>
     <if_stmt><if>if <condition><expr><call><name>str_check</name><argument_list>(<argument><expr><name>value</name></expr></argument>)</argument_list></call></expr></condition><block>:<block_content>
         <if_stmt><if>if <condition><expr><call><name><name>value</name><operator>.</operator><name>startswith</name></name><argument_list>(<argument><expr><literal type="string">"!"</literal></expr></argument>)</argument_list></call></expr></condition><block>:<block_content>
@@ -50,42 +50,42 @@
 </block_content></block></else></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>x</name> <operator>&lt;</operator> <literal type="number">0</literal></expr></condition><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'less than zero'</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><literal type="boolean">True</literal></expr></condition><block>:<block_content> <expr_stmt><expr><name>a</name> <operator>=</operator> <literal type="number">10</literal></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>x</name> <operator>&lt;</operator> <literal type="number">0</literal></expr></condition><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'less than zero'</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if>
 <if type="elseif">elif <condition><expr><name>x</name> <operator>==</operator> <literal type="number">0</literal></expr></condition><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'zero'</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>a</name> <operator>&gt;</operator> <literal type="number">0</literal></expr></condition><block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>a</name></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"positive"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if>
 <if type="elseif">elif <condition><expr><name>a</name> <operator>==</operator> <literal type="number">0</literal></expr></condition><block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>a</name></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"zero"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>x</name> <operator>&lt;</operator> <literal type="number">0</literal></expr></condition><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'less than zero'</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if>
 <else>else<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'greater than one'</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><literal type="boolean">True</literal></expr></condition><block>:<block_content> <expr_stmt><expr><name>a</name> <operator>=</operator> <literal type="number">10</literal></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if>
 <else>else<block>:<block_content> <expr_stmt><expr><name>a</name> <operator>=</operator> <literal type="number">0</literal></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="number">0</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>x</name> <operator>&lt;</operator> <literal type="number">0</literal></expr></condition><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'less than zero'</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if>
 <if type="elseif">elif <condition><expr><name>x</name> <operator>==</operator> <literal type="number">0</literal></expr></condition><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'zero'</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if>
 <if type="elseif">elif <condition><expr><name>x</name> <operator>==</operator> <literal type="number">1</literal></expr></condition><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'one'</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if>
 <else>else<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'greater than one'</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>a</name> <operator>&lt;</operator> <literal type="number">0</literal></expr></condition><block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>a</name></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'less than zero'</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if>
 <if type="elseif">elif <condition><expr><name>a</name> <operator>==</operator> <literal type="number">0</literal></expr></condition><block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>a</name></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'zero'</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if>
 <if type="elseif">elif <condition><expr><name>a</name> <operator>==</operator> <literal type="number">1</literal></expr></condition><block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>a</name></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'one'</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></if>

--- a/test/parser/testsuite/import_py.py.xml
+++ b/test/parser/testsuite/import_py.py.xml
@@ -1,83 +1,83 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="import">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import>import <name>module</name></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import>import <name>module_1</name>, <name>module_2</name></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import>import <name>module</name> <alias>as <expr><name>alias</name></expr></alias></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import>import <name>module_1</name> <alias>as <expr><name>alias_1</name></expr></alias>, <name>module_2</name> <alias>as <expr><name>alias_2</name></expr></alias></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>module</name></from> import <name>name</name></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>module</name></from> import (<name>name</name>)</import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>module</name></from> import <name>name_1</name>, <name>name_2</name></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>module</name></from> import (<name>name_1</name>, <name>name_2</name>)</import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>module</name></from> import <name>name</name> <alias>as <expr><name>alias</name></expr></alias></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>module</name></from> import (<name>name</name> <alias>as <expr><name>alias</name></expr></alias>)</import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>module</name></from> import <name>name_1</name> <alias>as <expr><name>name_1</name></expr></alias>, <name>name_2</name> <alias>as <expr><name>alias_2</name></expr></alias></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>module</name></from> import (<name>name_1</name> <alias>as <expr><name>name_1</name></expr></alias>, <name>name_2</name> <alias>as <expr><name>alias_2</name></expr></alias>)</import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>module</name></from> import <name>name_1</name>, <name>name_2</name> <alias>as <expr><name>alias</name></expr></alias>, <name>name_3</name></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>module</name></from> import (<name>name_1</name>, <name>name_2</name> <alias>as <expr><name>alias</name></expr></alias>, <name>name_3</name>)</import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>module</name></from> import <name>*</name></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>.</name></from> import <name>name</name></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>..</name></from> import <name>name</name></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>.module</name></from> import <name>name</name></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>..module</name></from> import <name>name</name></import>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <import><from>from <name>.module</name></from> import (
     <name>a</name>,
     <name>b</name>,

--- a/test/parser/testsuite/keyword_as_name_py.py.xml
+++ b/test/parser/testsuite/keyword_as_name_py.py.xml
@@ -1,211 +1,211 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="keyword_as_name">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>__asm</name> <operator>=</operator> <literal type="string">"__asm"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>__volatile__</name> <operator>=</operator> <literal type="string">"__volatile__"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>catch</name> <operator>=</operator> <literal type="string">"catch"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>const</name> <operator>=</operator> <literal type="string">"const"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>default</name> <operator>=</operator> <literal type="string">"default"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>enum</name> <operator>=</operator> <literal type="string">"enum"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>extern</name> <operator>=</operator> <literal type="string">"extern"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>explicit</name> <operator>=</operator> <literal type="string">"explicit"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>false</name> <operator>=</operator> <literal type="boolean">False</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>goto</name> <operator>=</operator> <literal type="string">"goto"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>inline</name> <operator>=</operator> <literal type="string">"inline"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>main</name> <operator>=</operator> <literal type="string">"main"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>namespace</name> <operator>=</operator> <literal type="string">"namespace"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>new</name> <operator>=</operator> <literal type="string">"new"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>omp</name> <operator>=</operator> <literal type="string">"omp"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>operator</name> <operator>=</operator> <literal type="string">"operator"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>private</name> <operator>=</operator> <literal type="string">"private"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>protected</name> <operator>=</operator> <literal type="string">"protected"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>public</name> <operator>=</operator> <literal type="string">"public"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>sizeof</name> <operator>=</operator> <literal type="string">"sizeof"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>static</name> <operator>=</operator> <literal type="string">"static"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>struct</name> <operator>=</operator> <literal type="string">"struct"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>switch</name> <operator>=</operator> <literal type="string">"switch"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>throw</name> <operator>=</operator> <literal type="string">"throw"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>true</name> <operator>=</operator> <literal type="boolean">True</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>typedef</name> <operator>=</operator> <literal type="string">"typedef"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>using</name> <operator>=</operator> <literal type="string">"using"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>virtual</name> <operator>=</operator> <literal type="string">"virtual"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>volatile</name> <operator>=</operator> <literal type="string">"volatile"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>case</name> <operator>=</operator> <literal type="number">1</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name><name>case</name><operator>.</operator><name>tag</name></name> <operator>=</operator> <literal type="number">1</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name><name>case</name><index>[<expr><literal type="string">"index"</literal></expr>]</index></name> <operator>=</operator> <literal type="number">1</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple><expr><name>case</name></expr>, <expr><name>_</name></expr></tuple> <operator>=</operator> <tuple><expr><literal type="number">1</literal></expr>, <expr><literal type="number">1</literal></expr></tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>case</name><annotation>: <expr><name>str</name></expr></annotation> <operator>=</operator> <literal type="string">"srcML"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>case</name><argument_list>()</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>match</name> <operator>=</operator> <literal type="number">2</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name><name>match</name><operator>.</operator><name>tag</name></name> <operator>=</operator> <literal type="number">2</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name><name>match</name><index>[<expr><literal type="string">"index"</literal></expr>]</index></name> <operator>=</operator> <literal type="number">2</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple><expr><name>match</name></expr>, <expr><name>_</name></expr></tuple> <operator>=</operator> <tuple><expr><literal type="number">2</literal></expr>, <expr><literal type="number">2</literal></expr></tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>match</name><annotation>: <expr><name>str</name></expr></annotation> <operator>=</operator> <literal type="string">"srcML"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>match</name><argument_list>()</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>type</name> <operator>=</operator> <literal type="number">3</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name><name>type</name><operator>.</operator><name>tag</name></name> <operator>=</operator> <literal type="number">3</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name><name>type</name><index>[<expr><literal type="string">"index"</literal></expr>]</index></name> <operator>=</operator> <literal type="number">3</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple><expr><name>type</name></expr>, <expr><name>_</name></expr></tuple> <operator>=</operator> <tuple><expr><literal type="number">3</literal></expr>, <expr><literal type="number">3</literal></expr></tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>type</name><annotation>: <expr><name>str</name></expr></annotation> <operator>=</operator> <literal type="string">"srcML"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>type</name><argument_list>()</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name> <argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>exec</name><argument_list>(<argument><expr><literal type="string">"print(a)"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>exec</name> <argument_list>(<argument><expr><literal type="string">"print (a)"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match<condition><expr><operator>(</operator><call><name>match</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><operator>)</operator></expr></condition><block>:<block_content>
     <case>case<expr><operator>(</operator><call><name>case</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call><operator>)</operator></expr><block>:<block_content>
         <expr_stmt><expr><call><name>case</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
@@ -214,7 +214,7 @@
 </block_content></block></case></block_content></block></switch>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match<condition><expr><operator>(</operator>
     <call><name>match</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call>
 <operator>)</operator></expr></condition><block>:<block_content>

--- a/test/parser/testsuite/lambda_py.py.xml
+++ b/test/parser/testsuite/lambda_py.py.xml
@@ -1,100 +1,100 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="lambda">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><lambda>lambda <parameter><name>string</name></parameter> : <expr><call><name>print</name><argument_list>(<argument><expr><name>string</name></expr></argument>)</argument_list></call></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><lambda>lambda <parameter><name>x</name></parameter>, <parameter><name>y</name></parameter> : <expr><name>x</name> <operator>+</operator> <name>y</name></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><lambda>lambda <parameter><name>value</name> <init>= <expr><literal type="null">None</literal></expr></init></parameter> : <expr><call><name>str</name><argument_list>(<argument><expr><name>value</name></expr></argument>)</argument_list></call></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><lambda>lambda <parameter><name>value</name> <init>= <expr><dictionary>{<expr><literal type="null">None</literal></expr>: <expr><literal type="null">None</literal></expr>}</dictionary></expr></init></parameter> : <expr><call><name>str</name><argument_list>(<argument><expr><name>value</name></expr></argument>)</argument_list></call></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><operator>*</operator><name>x</name></expr></argument>, <argument><expr><operator>**</operator><name>x</name></expr></argument>)</argument_list></call></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><operator>**</operator><name>x</name></expr></argument>, <argument><expr><operator>*</operator><name>x</name></expr></argument>)</argument_list></call></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>simple_print</name> <operator>=</operator> <lambda>lambda <parameter><name>x</name></parameter> : <expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>simple_print</name> <operator>=</operator> <operator>(</operator><lambda>lambda <parameter><name>x</name></parameter> : <expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></lambda><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>func</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>, <argument><expr><lambda>lambda <parameter><name>a</name></parameter> : <expr><call><name>print</name><argument_list>(<argument><expr><name>a</name> <operator>**</operator> <literal type="number">2</literal></expr></argument>)</argument_list></call></expr></lambda></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><name>x</name></expr></argument>, <argument><expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr></lambda></expr></argument>)</argument_list></call></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><lambda>lambda <parameter><name>y</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>example</name><argument_list>(<argument><expr><operator>*</operator><name>x</name></expr></argument>)</argument_list></call></expr></lambda></expr></argument>, <argument><expr><operator>*</operator><name>y</name></expr></argument>)</argument_list></call></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><lambda>lambda <parameter><name>y</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>example</name><argument_list>(<argument><expr><operator>**</operator><name>x</name></expr></argument>)</argument_list></call></expr></lambda></expr></argument>, <argument><expr><operator>**</operator><name>y</name></expr></argument>)</argument_list></call></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>(</operator>
     <lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr></argument>)</argument_list></call></expr></lambda>
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(
     <expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr></argument>)</argument_list></call></expr></lambda></expr>,
     <expr><literal type="string">"default"</literal></expr>,
 )</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[
     <expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr></argument>)</argument_list></call></expr></lambda></expr>,
     <expr><literal type="string">"default"</literal></expr>,
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{
     <expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr></argument>)</argument_list></call></expr></lambda></expr>,
     <expr><literal type="string">"default"</literal></expr>,
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{
     <expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><tuple>(<expr><lambda>lambda <parameter><name>y</name></parameter>: <expr><name>y</name><operator>**</operator><literal type="number">2</literal></expr></lambda></expr>, <expr><name>b</name></expr>)</tuple></expr></argument>)</argument_list></call></expr></lambda></expr>,
     <expr><literal type="string">"default"</literal></expr>,
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{
     <expr><literal type="string">"x1"</literal></expr>: <expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr></argument>)</argument_list></call></expr></lambda></expr>,
     <expr><literal type="string">"x2"</literal></expr>: <expr><literal type="string">"default"</literal></expr>,
 }</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>sample</name> <operator>=</operator> <array>[
     <expr><tuple>(
         <expr><lambda>lambda: <expr><call><name><name>a</name><operator>.</operator><name>example</name></name><argument_list>(
@@ -105,31 +105,31 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><operator>(</operator><lambda>lambda <parameter><name>a</name></parameter>: <expr><name>a</name><operator>**</operator><literal type="number">2</literal></expr></lambda><operator>)</operator></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name>example</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr></lambda></expr></argument>, <argument><expr><name>numbers</name></expr></argument>)</argument_list></call></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name>example</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>x</name></parameter>: <expr><call><name>sample</name><argument_list>(<argument><expr><name>x</name></expr></argument>, <argument><expr><name>x</name><operator>**</operator><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></lambda></expr></argument>, <argument><expr><name>numbers</name></expr></argument>)</argument_list></call></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><call><name>example</name><argument_list>(<argument><expr><call><name>sample</name><argument_list>(<argument><expr><lambda>lambda <parameter><name>a</name></parameter>: <expr><name>a</name><operator>**</operator><literal type="number">2</literal></expr></lambda></expr></argument>, <argument><expr><name>b</name></expr></argument>)</argument_list></call></expr></argument>, <argument><expr><name>c</name></expr></argument>)</argument_list></call></expr></condition>, <expr><literal type="string">"Fail Message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><lambda>lambda <parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>: <expr><name>a</name><operator>**</operator><name>b</name></expr></lambda></expr></condition>, <expr><literal type="string">"Fail message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><operator>(</operator><lambda>lambda <parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>: <expr><name>a</name><operator>**</operator><name>b</name></expr></lambda><operator>)</operator></expr></condition>, <expr><literal type="string">"Fail message"</literal></expr></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert <condition><expr><tuple>(<expr><lambda>lambda <parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>: <expr><name>a</name><operator>**</operator><name>b</name></expr></lambda></expr>, <expr><lambda>lambda <parameter><name>c</name></parameter>, <parameter><name>d</name></parameter>: <expr><name>c</name><operator>**</operator><name>d</name></expr></lambda></expr>)</tuple></expr></condition>, <expr><literal type="string">"Fail message"</literal></expr></assert>
 </unit>
 

--- a/test/parser/testsuite/literal_py.py.xml
+++ b/test/parser/testsuite/literal_py.py.xml
@@ -1,201 +1,201 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="literal">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">1</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">0</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>-</operator><literal type="number">1</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">1.1</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">.1</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">1.</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">0.0</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>-</operator><literal type="number">1.1</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>-</operator><literal type="number">.1</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>-</operator><literal type="number">1.</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">6_000_000</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">6_0_0_0</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">"c"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">'c'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">"ch"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">'ch'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r"\n"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r'\n'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">f"{x}"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">f'{x}'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">u"4"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">u'4'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">"""
 multiline
 """</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">'''
 multiline
 '''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">"also\
 multiline\
 with no\
 newlines"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">'also\
 multiline\
 with no\
 newlines'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">b"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">b'a'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="complex">5j</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="complex">0j</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>-</operator><literal type="complex">1j</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="complex">5 + 3j</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">10</literal> <operator>+</operator> <literal type="complex">5 + 3j</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">0b10101</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>-</operator><literal type="number">0b111</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">0o350</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>-</operator><literal type="number">0o777</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>-</operator><literal type="number">0xA8</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">0xFF</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">2.556e4</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">1.45e-3</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">2.556E4</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">1.45E-3</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="boolean">True</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="boolean">False</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="null">None</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="ellipsis">...</literal></expr></expr_stmt>
 </unit>
 

--- a/test/parser/testsuite/multiline_py.py.xml
+++ b/test/parser/testsuite/multiline_py.py.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="multiline">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>,
       <argument><expr><literal type="number">2</literal></expr></argument>,
       <argument><expr><literal type="number">3</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(
     <argument><expr><literal type="number">1</literal></expr></argument>,
     <argument><expr><literal type="number">2</literal></expr></argument>,
@@ -20,7 +20,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(
     <comment type="line"># Comment A</comment>
     <argument><expr><literal type="number">1</literal></expr></argument>,
@@ -32,7 +32,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(
     <argument><expr><literal type="number">1</literal></expr></argument>,
 
@@ -46,13 +46,13 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name><name>sample</name><index>[
     <expr><literal type="string">"a"</literal></expr>
 ]</index></name><argument_list>(<argument><expr><name>b</name></expr></argument>, <argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name><name>sample</name><index>[
     <expr><literal type="string">"a"</literal></expr>
 ]</index><index>[
@@ -60,7 +60,7 @@
 ]</index></name><argument_list>(<argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>, <argument><expr><name>e</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>example</name><argument_list>(
     <argument><expr><call><name><name>sample</name><index>[
         <expr><literal type="string">"a"</literal></expr>
@@ -70,7 +70,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name><name>example</name><index>[
     <expr><literal type="string">"a"</literal></expr>
 ]</index></name><argument_list>(
@@ -82,7 +82,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <call><name>a</name><argument_list>(
     <argument><expr><name>b</name></expr></argument>,
     <argument><expr><lambda>lambda <parameter><name>c</name></parameter>: <expr><call><name>d</name><argument_list>(
@@ -93,7 +93,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <call><name>a</name><argument_list>(
     <argument><expr><name>b</name></expr></argument>,
     <argument><expr><lambda>lambda <parameter><name>c</name></parameter>: <expr><call><name>d</name><argument_list>(
@@ -104,19 +104,19 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>bar</name><parameter_list>()</parameter_list><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="number">1</literal></expr></argument>,
                  <argument><expr><literal type="number">2</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>bar</name><parameter_list>()</parameter_list><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(
     <argument><expr><literal type="number">1</literal></expr></argument>,
     <argument><expr><literal type="number">2</literal></expr></argument>
 )</argument_list></call></expr></expr_stmt></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>bar</name><parameter_list>()</parameter_list><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(
     <comment type="line"># Comment A</comment>
     <argument><expr><literal type="number">1</literal></expr></argument>,
@@ -126,14 +126,14 @@
 )</argument_list></call></expr></expr_stmt></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>,
         <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>,
         <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><operator>(</operator>
@@ -142,7 +142,7 @@
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(
     <parameter><name>a</name></parameter>,
     <parameter><name>b</name></parameter>
@@ -151,7 +151,7 @@
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(
     <parameter><name>a</name></parameter>,
     <parameter><name>b</name></parameter>
@@ -164,7 +164,7 @@
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(
     <comment type="line"># Comment A</comment>
     <parameter><name>a</name></parameter>,
@@ -184,13 +184,13 @@
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>array</name> <operator>=</operator> <array>[<expr><literal type="number">1</literal></expr>,
          <expr><literal type="number">2</literal></expr>,
          <expr><literal type="number">3</literal></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>array</name> <operator>=</operator> <array>[
     <expr><literal type="number">1</literal></expr>,
     <expr><literal type="number">2</literal></expr>,
@@ -198,7 +198,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>array</name> <operator>=</operator> <array>[
     <comment type="line"># Comment A</comment>
     <expr><literal type="number">1</literal></expr>,
@@ -210,13 +210,13 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>dictionary</name> <operator>=</operator> <dictionary>{<expr><literal type="string">"a"</literal></expr>: <expr><literal type="number">1</literal></expr>,
               <expr><literal type="string">"b"</literal></expr>: <expr><literal type="number">2</literal></expr>,
               <expr><literal type="string">"c"</literal></expr>: <expr><literal type="number">3</literal></expr>}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>dictionary</name> <operator>=</operator> <dictionary>{
     <expr><literal type="string">"a"</literal></expr>: <expr><literal type="number">1</literal></expr>,
     <expr><literal type="string">"b"</literal></expr>: <expr><literal type="number">2</literal></expr>,
@@ -224,7 +224,7 @@
 }</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>dictionary</name> <operator>=</operator> <dictionary>{
     <comment type="line"># Comment A</comment>
     <expr><literal type="string">"a"</literal></expr>:
@@ -242,13 +242,13 @@
 }</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>set_py</name> <operator>=</operator> <set>{<expr><literal type="number">1</literal></expr>,
           <expr><literal type="number">2</literal></expr>,
           <expr><literal type="number">3</literal></expr>}</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>set_py</name> <operator>=</operator> <set>{
     <expr><literal type="number">1</literal></expr>,
     <expr><literal type="number">2</literal></expr>,
@@ -256,7 +256,7 @@
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>set_py</name> <operator>=</operator> <set>{
     <comment type="line"># Comment A</comment>
     <expr><literal type="number">1</literal></expr>,
@@ -268,13 +268,13 @@
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>tuple_py</name> <operator>=</operator> <tuple>(<expr><literal type="number">1</literal></expr>,
             <expr><literal type="number">2</literal></expr>,
             <expr><literal type="number">3</literal></expr>)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>tuple_py</name> <operator>=</operator> <tuple>(
     <expr><literal type="number">1</literal></expr>,
     <expr><literal type="number">2</literal></expr>,
@@ -282,7 +282,7 @@
 )</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>tuple_py</name> <operator>=</operator> <tuple>(
     <comment type="line"># Comment A</comment>
     <expr><literal type="number">1</literal></expr>,
@@ -294,12 +294,12 @@
 )</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>operator</name> <operator>=</operator> <operator>(</operator><literal type="number">1</literal> <operator>+</operator>
             <literal type="number">2</literal><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>operator</name> <operator>=</operator> <operator>(</operator>
     <literal type="number">1</literal>
     <operator>+</operator>
@@ -307,7 +307,7 @@
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>operator</name> <operator>=</operator> <operator>(</operator>
     <comment type="line"># Comment A</comment>
     <literal type="number">1</literal>
@@ -319,13 +319,13 @@
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>index</name> <operator>=</operator> <name><name>sample</name><index>[<expr><literal type="number">0</literal>
                <operator>:</operator>
                <literal type="number">5</literal></expr>]</index></name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>index</name> <operator>=</operator> <name><name>sample</name><index>[
     <expr><literal type="number">0</literal>
     <operator>:</operator>
@@ -333,7 +333,7 @@
 ]</index></name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>index</name> <operator>=</operator> <name><name>sample</name><index>[
     <comment type="line"># Comment A</comment>
     <expr><literal type="number">0</literal>
@@ -345,7 +345,7 @@
 ]</index></name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>ternary</name> <operator>=</operator> <operator>(</operator>
     <literal type="string">"hello"</literal>
     <ternary>if
@@ -355,7 +355,7 @@
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>ternary</name> <operator>=</operator> <operator>(</operator>
     <comment type="line"># Comment A</comment>
     <literal type="string">"hello"</literal>
@@ -371,7 +371,7 @@
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>ternary</name> <operator>=</operator> <operator>(</operator>
     <literal type="number">1</literal>
     <ternary>if
@@ -381,7 +381,7 @@
 <operator>)</operator> <ternary>if <condition><expr><literal type="number">4</literal></expr></condition> <else>else <expr><literal type="number">5</literal></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>ternary</name> <operator>=</operator> <operator>(</operator>
     <comment type="line"># Comment A</comment>
     <literal type="number">1</literal>
@@ -397,7 +397,7 @@
 <operator>)</operator> <ternary>if <condition><expr><literal type="number">4</literal></expr></condition> <else>else <expr><literal type="number">5</literal></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>ternary</name> <operator>=</operator> <literal type="number">1</literal> <ternary>if <condition><expr><operator>(</operator>
     <literal type="number">2</literal>
     <ternary>if
@@ -407,7 +407,7 @@
 <operator>)</operator></expr></condition> <else>else <expr><literal type="number">5</literal></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>ternary</name> <operator>=</operator> <literal type="number">1</literal> <ternary>if <condition><expr><operator>(</operator>
     <comment type="line"># Comment A</comment>
     <literal type="number">2</literal>
@@ -423,7 +423,7 @@
 <operator>)</operator></expr></condition> <else>else <expr><literal type="number">5</literal></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>ternary</name> <operator>=</operator> <literal type="number">1</literal> <ternary>if <condition><expr><literal type="number">2</literal></expr></condition> <else>else <expr><operator>(</operator>
     <literal type="number">3</literal>
     <ternary>if
@@ -433,7 +433,7 @@
 <operator>)</operator></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>ternary</name> <operator>=</operator> <literal type="number">1</literal> <ternary>if <condition><expr><literal type="number">2</literal></expr></condition> <else>else <expr><operator>(</operator>
     <comment type="line"># Comment A</comment>
     <literal type="number">3</literal>
@@ -449,7 +449,7 @@
 <operator>)</operator></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <array>[
     <expr><name>x</name></expr>
     <comprehension><for>for
@@ -461,7 +461,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <array>[
     <comment type="line"># Comment A</comment>
     <expr><name>x</name></expr>
@@ -481,7 +481,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <array>[
     <expr><name>x</name></expr>
     <comprehension><for>for
@@ -499,7 +499,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <array>[
     <comment type="line"># Comment A</comment>
     <expr><name>x</name></expr>
@@ -531,7 +531,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <array>[
     <expr><name>x</name></expr>
     <comprehension><for>for
@@ -553,7 +553,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <array>[
     <comment type="line"># Comment A</comment>
     <expr><name>x</name></expr>
@@ -593,7 +593,7 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <set>{
     <expr><name>x</name></expr>
     <comprehension><for>for
@@ -605,7 +605,7 @@
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <set>{
     <comment type="line"># Comment A</comment>
     <expr><name>x</name></expr>
@@ -625,7 +625,7 @@
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <set>{
     <expr><name>x</name></expr>
     <comprehension><for>for
@@ -643,7 +643,7 @@
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <set>{
     <comment type="line"># Comment A</comment>
     <expr><name>x</name></expr>
@@ -675,7 +675,7 @@
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <set>{
     <expr><name>x</name></expr>
     <comprehension><for>for
@@ -697,7 +697,7 @@
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <set>{
     <comment type="line"># Comment A</comment>
     <expr><name>x</name></expr>
@@ -737,7 +737,7 @@
 }</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <dictionary>{
     <expr><name>x</name></expr>
     :
@@ -751,7 +751,7 @@
 }</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <dictionary>{
     <comment type="line"># Comment A</comment>
     <expr><name>x</name></expr>
@@ -775,7 +775,7 @@
 }</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <dictionary>{
     <expr><name>x</name></expr>
     :
@@ -795,7 +795,7 @@
 }</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <dictionary>{
     <comment type="line"># Comment A</comment>
     <expr><name>x</name></expr>
@@ -831,7 +831,7 @@
 }</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <dictionary>{
     <expr><name>x</name></expr>
     :
@@ -855,7 +855,7 @@
 }</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>list_comp</name> <operator>=</operator> <dictionary>{
     <comment type="line"># Comment A</comment>
     <expr><name>x</name></expr>
@@ -899,13 +899,13 @@
 }</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <typedef>type <name><name>ListOrSet</name><parameter_list type="generic">[
     <parameter><name>T</name></parameter>
 ]</parameter_list></name> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>T</name></expr>]</index></name></expr></typedef>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <typedef>type <name><name>ListOrSet</name><parameter_list type="generic">[
     <comment type="line"># Comment A</comment>
     <parameter><name>T</name></parameter>
@@ -913,14 +913,14 @@
 ]</parameter_list></name> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>T</name></expr>]</index></name></expr></typedef>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <typedef>type <name><name>ListOrSet</name><parameter_list type="generic">[
     <parameter><name>T</name></parameter>,
     <parameter><name>U</name></parameter>
 ]</parameter_list></name> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>U</name></expr>]</index></name></expr></typedef>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <typedef>type <name><name>ListOrSet</name><parameter_list type="generic">[
     <comment type="line"># Comment A</comment>
     <parameter><name>T</name></parameter>,
@@ -930,7 +930,7 @@
 ]</parameter_list></name> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>U</name></expr>]</index></name></expr></typedef>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name><name>max</name><parameter_list type="generic">[
     <parameter><name>T</name></parameter>,
     <parameter><name>U</name></parameter>
@@ -939,7 +939,7 @@
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name><name>max</name><parameter_list type="generic">[
     <comment type="line"># Comment A</comment>
     <parameter><name>T</name></parameter>,
@@ -951,7 +951,7 @@
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name><name>list</name><parameter_list type="generic">[
     <parameter><name>T</name></parameter>,
     <parameter><name>U</name></parameter>
@@ -961,7 +961,7 @@
 </block_content></block></function></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name><name>list</name><parameter_list type="generic">[
     <comment type="line"># Comment A</comment>
     <parameter><name>T</name></parameter>,
@@ -974,7 +974,7 @@
 </block_content></block></function></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Box</name><super_list>(
     <super><expr><name><name>Generic</name><index>[<expr><name>T</name></expr>]</index></name></expr></super>,
     <super><expr><name><name>Generic</name><index>[<expr><name>U</name></expr>]</index></name></expr></super>
@@ -984,7 +984,7 @@
 </block_content></block></function></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Box</name><super_list>(
     <comment type="line"># Comment A</comment>
     <super><expr><name><name>Generic</name><index>[<expr><name>T</name></expr>]</index></name></expr></super>,
@@ -997,7 +997,7 @@
 </block_content></block></function></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name><name>Box</name><parameter_list type="generic">[
     <parameter><name>T</name></parameter>,
     <parameter><name>U</name></parameter>
@@ -1010,7 +1010,7 @@
 </block_content></block></function></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name><name>Box</name><parameter_list type="generic">[
     <comment type="line"># Comment A</comment>
     <parameter><name>T</name></parameter>,
@@ -1029,13 +1029,13 @@
 </block_content></block></function></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>line_continuation</name> <operator>=</operator> <literal type="string">"Lorem ipsum dolor sit amet, \
 consectetur adipiscing elit. Nullam condimentum \
 ligula a lectus maximus mollis."</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>line_continuation</name> <operator>=</operator> <name>a</name> <operator>+</operator> \
                     <name>b</name> <operator>-</operator> \
                     <name>c</name> <operator>*</operator> \
@@ -1043,7 +1043,7 @@ ligula a lectus maximus mollis."</literal></expr></expr_stmt>
                     <name>e</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>example</name><parameter_list>(<parameter><name>self</name></parameter>)</parameter_list><block>:<block_content>
     <if_stmt><if>if <condition><expr><name>a</name></expr></condition><block>:<block_content>
         <return>return <expr><tuple><expr><name>b</name></expr>, <expr><literal type="string">'(c: %s, d: %s)'</literal> <operator>%</operator> \
@@ -1051,7 +1051,7 @@ ligula a lectus maximus mollis."</literal></expr></expr_stmt>
 </block_content></block></if></if_stmt></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>example</name><parameter_list>(<parameter><name>self</name></parameter>)</parameter_list><block>:<block_content>
     <if_stmt><if>if <condition><expr><name>a</name></expr></condition><block>:<block_content>
         <return>return \
@@ -1061,19 +1061,19 @@ ligula a lectus maximus mollis."</literal></expr></expr_stmt>
 </block_content></block></if></if_stmt></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>line_continuation</name> <operator>=</operator> <name>a</name> \
                     <ternary>if <condition><expr><name>b</name></expr></condition> \
                     <else>else <expr><name>c</name></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert \
     <condition><expr><name>x</name> <operator>==</operator> \
     <name>y</name></expr></condition></assert>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert \
        \
        <condition><expr><literal type="number">4</literal>\
@@ -1087,7 +1087,7 @@ ligula a lectus maximus mollis."</literal></expr></expr_stmt>
 
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert \
        \
        <condition><expr><literal type="number">4</literal>\
@@ -1101,7 +1101,7 @@ ligula a lectus maximus mollis."</literal></expr></expr_stmt>
 
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert \
        \
        <condition><expr><literal type="number">4</literal>\
@@ -1118,7 +1118,7 @@ ligula a lectus maximus mollis."</literal></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <assert>assert \
        \
        <condition><expr><literal type="number">4</literal>\

--- a/test/parser/testsuite/nonlocal_py.py.xml
+++ b/test/parser/testsuite/nonlocal_py.py.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="nonlocal">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>outer</name><parameter_list>(<parameter><name>x</name></parameter>)</parameter_list><block>:<block_content>
     <function>def <name>inner</name><parameter_list>()</parameter_list><block>:<block_content>
         <nonlocal>nonlocal <name>x</name></nonlocal>

--- a/test/parser/testsuite/operator_py.py.xml
+++ b/test/parser/testsuite/operator_py.py.xml
@@ -1,227 +1,227 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="operator">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>+</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>-</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>*</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>/</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>%</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>**</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>//</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>@</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>+</operator><name>num</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>-</operator><name>num</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>&amp;</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>|</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>^</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>example_one</name><argument_list>(<argument><expr><name>x</name> <operator>^</operator> <name><name>y</name><index>[<expr><name>z</name></expr>]</index></name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>~</operator><name>value</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>&lt;&lt;</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>&gt;&gt;</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>==</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>!=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>&gt;</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>&lt;</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>&gt;=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>&lt;=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>&lt;&gt;</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>(</operator><name>x</name> <operator>:=</operator> <name>y</name><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>+=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>-=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>*=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>/=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>%=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>**=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>//=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>@=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>&amp;=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>|=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>^=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>&lt;&lt;=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>&gt;&gt;=</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name><name>x</name><operator>.</operator><name>y</name></name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><operator>*</operator><name>args</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><operator>**</operator><name>kwargs</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name><name>array</name><index>[<expr><name>x</name><operator>:</operator><name>y</name></expr>]</index></name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name><name>array</name><index>[<expr><operator>:</operator><name>y</name></expr>]</index></name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name><name>array</name><index>[<expr><name>x</name><operator>:</operator></expr>]</index></name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name><name>array</name><index>[<expr><operator>:</operator></expr>]</index></name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>and</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>or</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>not</operator> <name>value</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>is</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>is not</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>in</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>not in</operator> <name>y</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>await</operator> <name>x</name></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>await</operator> <call><name>async_print</name><argument_list>()</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>x</name> <operator>:=</operator> <literal type="number">10</literal></expr></condition><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></if></if_stmt>

--- a/test/parser/testsuite/parameter_py.py.xml
+++ b/test/parser/testsuite/parameter_py.py.xml
@@ -1,91 +1,91 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="parameter">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>do_nothing</name><parameter_list>()</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>simple_print</name><parameter_list>(<parameter><name>val</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>printf</name><parameter_list>(<parameter><name>val</name></parameter>,<parameter><name>string</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><call><name><name>string</name><operator>.</operator><name>format</name></name><argument_list>(<argument><expr><name>val</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><name>a</name> <operator>+</operator> <name>b</name></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>calc</name><parameter_list>(<parameter><name>x</name></parameter>, <parameter><name>y</name> <init>= <expr><literal type="number">0</literal></expr></init></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><name>x</name> <operator>+</operator> <name>y</name></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name> <init>= <expr><literal type="number">0</literal></expr></init></parameter>, <parameter><name>b</name> <init>= <expr><literal type="number">0</literal></expr></init></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><name>a</name> <operator>+</operator> <name>b</name></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>printf</name><parameter_list>(<parameter><name>val</name></parameter>,<parameter><name>string</name><annotation>: <expr><name>str</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><call><name><name>string</name><operator>.</operator><name>format</name></name><argument_list>(<argument><expr><name>val</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sumIntegers</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>, <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><name>a</name> <operator>+</operator> <name>b</name></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>invert</name><parameter_list>(<parameter><name>val</name><annotation>: <expr><name>int</name></expr></annotation> <init>= <expr><literal type="number">0</literal></expr></init></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><operator>~</operator><name>val</name></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sumIntegers</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation> <init>= <expr><literal type="number">0</literal></expr></init></parameter>, <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation> <init>= <expr><literal type="number">0</literal></expr></init></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><name>a</name> <operator>+</operator> <name>b</name></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>pos_function</name><parameter_list>(<parameter><name>x</name></parameter>, <parameter type="modifier">*</parameter>, <parameter><name>y</name></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><name>x</name> <operator>-</operator> <name>y</name></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>key_function</name><parameter_list>(<parameter><name>x</name></parameter>, <parameter><name>y</name></parameter>, <parameter type="modifier">/</parameter>, <parameter><name>z</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>z</name><operator>*</operator><operator>(</operator><name>x</name><operator>+</operator><name>y</name><operator>)</operator></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>arg_test</name><parameter_list>(<parameter type="args">*<name>args</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>args</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>example</name><parameter_list>(<parameter><name>x</name><init>=<expr><name>x</name></expr></init></parameter>, <parameter><name>y</name><init>=<expr><call><name><name>y</name><operator>.</operator><name>transpose</name></name><argument_list>(<argument><expr><operator>-</operator><literal type="number">2</literal></expr></argument>, <argument><expr><operator>-</operator><literal type="number">1</literal></expr></argument>)</argument_list></call></expr></init></parameter>)</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>add</name><parameter_list>(<parameter type="args">*<name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><name>result</name> <operator>=</operator> <literal type="number">0</literal></expr></expr_stmt>
     <for>for <control><expr><name>i</name></expr> <range>in <expr><name>b</name></expr></range></control><block>:<block_content>
@@ -94,43 +94,43 @@
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>kwarg_test</name><parameter_list>(<parameter type="kwargs">**<name>kwargs</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>kwargs</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>add</name><parameter_list>(<parameter type="kwargs">**<name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <for>for <control><expr><name>i</name></expr> <range>in <expr><call><name><name>a</name><operator>.</operator><name>items</name></name><argument_list>()</argument_list></call></expr></range></control><block>:<block_content>
         <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>i</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></for></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>hinting</name><parameter_list>(<parameter type="args">*<name>args</name><annotation>: <expr><name>list</name></expr></annotation></parameter>, <parameter type="kwargs">**<name>kwargs</name><annotation>: <expr><name>dict</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>args</name></expr></argument>,<argument><expr><name>kwargs</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>all</name><parameter_list>(<parameter><name>x</name></parameter>, <parameter type="modifier">/</parameter>, <parameter><name>y</name></parameter>, <parameter type="modifier">*</parameter>, <parameter><name>z</name></parameter>)</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><lambda>lambda <parameter><name>x</name></parameter>, <parameter><name>y</name></parameter> : <expr><name>x</name> <operator>+</operator> <name>y</name></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>numberGenerator</name><parameter_list>(<parameter><name>number_range</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <for>for <control><expr><name>i</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><name>number_range</name><operator>+</operator><literal type="number">1</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
         <yield>yield <expr><name>i</name></expr></yield>
 </block_content></block></for></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>loudNumberGenerator</name><parameter_list>(<parameter><name>number_range</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><name>normal_number_generator</name> <operator>=</operator> <call><name>numberGenerator</name><argument_list>(<argument><name>number_range</name>=<expr><name>number_range</name></expr></argument>)</argument_list></call></expr></expr_stmt>
     <while>while <condition><expr><literal type="boolean">True</literal></expr></condition><block>:<block_content>
@@ -138,13 +138,13 @@
 </block_content></block></while></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name><name>max</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list></name><parameter_list>(<parameter><name>args</name><annotation>: <expr><name><name>Iterable</name><index>[<expr><name>T</name></expr>]</index></name></expr></annotation></parameter>)</parameter_list> <annotation>-&gt; <expr><name>T</name></expr></annotation><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"srcML"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>example</name><parameter_list>(
     <parameter><name>a</name></parameter>,
     <parameter><name>b</name></parameter>,
@@ -154,7 +154,7 @@
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>example</name><parameter_list>(
     <parameter><name>a</name></parameter>,
     <parameter><name>b</name><annotation>: <expr><name><name>dict</name><index>[<expr><name>str</name></expr>, <expr><name>str</name></expr>]</index></name> <operator>|</operator> <literal type="null">None</literal></expr></annotation> <init>= <expr><literal type="null">None</literal></expr></init></parameter>,
@@ -164,7 +164,7 @@
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name><name>example</name><parameter_list type="generic">[<parameter><name>T</name></parameter>, <parameter><name>U</name></parameter>, <parameter><name>V</name></parameter>,]</parameter_list></name><parameter_list>(
     <parameter><name>a</name></parameter>,
     <parameter><name>b</name></parameter>,

--- a/test/parser/testsuite/pass_py.py.xml
+++ b/test/parser/testsuite/pass_py.py.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="pass">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><literal type="boolean">True</literal></expr></condition><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></if><if type="elseif">elif <condition><expr><literal type="boolean">False</literal></expr></condition><block>:<block_content>
@@ -11,7 +11,7 @@
 </block_content></block></else></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>val</name></expr> <range>in <expr><name>arr</name></expr></range></control><block>:<block_content>
     <pass>pass</pass>
 </block_content></block><else>else<block>:<block_content>
@@ -19,7 +19,7 @@
 </block_content></block></else></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><literal type="boolean">False</literal></expr></condition><block>:<block_content>
     <pass>pass</pass>
 </block_content></block><else>else<block>:<block_content>
@@ -27,32 +27,32 @@
 </block_content></block></else></while>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">"test.txt"</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file</name></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><name>x</name></expr></condition><block>:<block_content>
     <case>case <expr><literal type="number">1</literal></expr><block>:<block_content>
         <pass>pass</pass>
 </block_content></block></case></block_content></block></switch>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>func</name><parameter_list>()</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <pass>pass</pass>
 </block_content></block><catch>except<block>:<block_content>

--- a/test/parser/testsuite/python_2_py.py.xml
+++ b/test/parser/testsuite/python_2_py.py.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="python_2">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <exec>exec <expr><literal type="string">"x = 4"</literal></expr></exec>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>exec</name><argument_list>(<argument><expr><literal type="string">"x = 4"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>exec</name> <argument_list>(<argument><expr><literal type="string">"x = 4"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <print>print <expr><literal type="string">"Hello World"</literal></expr></print>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Hello World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name> <argument_list>(<argument><expr><literal type="string">"Hello World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Sample</name><super_list>()</super_list><block>:<block_content>
     <function>def <name>example</name><parameter_list>(<parameter><name>self</name></parameter>)</parameter_list><block>:<block_content>
         <print>print <expr><tuple><expr><literal type="string">"A"</literal></expr>, <expr><name>a</name></expr>, <expr><literal type="string">"B"</literal></expr>, <expr><name>b</name></expr>, <expr><literal type="string">"."</literal></expr>,</tuple></expr></print> \
@@ -34,7 +34,7 @@
 <expr_stmt><expr><name>c</name> <operator>=</operator> <literal type="number">0</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <alias><expr><name>ZeroDivisionError</name></expr>, <name>e</name></alias><block>:<block_content>
@@ -42,7 +42,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <alias><expr><tuple>(<expr><name>ZeroDivisionError</name></expr>, <expr><name>ValueError</name></expr>, <expr><name>TypeError</name></expr>)</tuple></expr>, <name>e</name></alias><block>:<block_content>
@@ -50,7 +50,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <alias><expr><operator>(</operator><name>ZeroDivisionError</name><operator>)</operator></expr>, <operator>(</operator><name>e</name><operator>)</operator></alias><block>:<block_content>
@@ -58,19 +58,19 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">ur"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">UR"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">Ur"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">uR"a"</literal></expr></expr_stmt>
 </unit>
 

--- a/test/parser/testsuite/return_py.py.xml
+++ b/test/parser/testsuite/return_py.py.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="return">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>void</name><parameter_list>()</parameter_list><block>:<block_content>
     <return>return</return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>get_true</name><parameter_list>()</parameter_list><block>:<block_content>
     <return>return <expr><literal type="boolean">True</literal></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>calc</name><parameter_list>(<parameter><name>x</name></parameter>,<parameter><name>y</name></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><name>x</name> <operator>+</operator> <name>y</name></expr></return>
 </block_content></block></function>

--- a/test/parser/testsuite/set_py.py.xml
+++ b/test/parser/testsuite/set_py.py.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="set">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{<expr><literal type="number">1</literal></expr>}</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>}</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{<expr><literal type="number">1</literal></expr>,<expr><literal type="number">2</literal></expr>,<expr><literal type="number">3</literal></expr>}</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{<expr><literal type="number">1</literal></expr>,}</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>=</operator> <set>{<expr><literal type="string">'a'</literal></expr>,<expr><literal type="string">'b'</literal></expr>,<expr><literal type="string">'c'</literal></expr>}</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{<expr><literal type="number">1</literal></expr>,<expr><literal type="string">'2'</literal></expr>,<expr><literal type="boolean">True</literal></expr>}</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{<expr><name>x</name></expr> <comprehension><for>for <control><expr><name>x</name></expr> <range>in <expr><call><name>print</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>}</set></expr></expr_stmt>
 </unit>
 

--- a/test/parser/testsuite/specifier_py.py.xml
+++ b/test/parser/testsuite/specifier_py.py.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="specifier">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for><specifier>async</specifier> for <control><expr><name>x</name></expr> <range>in <expr><call><name>async_range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
     <expr_stmt><expr><operator>await</operator> <call><name>async_print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><name>x</name></expr> <comprehension><for><specifier>async</specifier> for <control><expr><name>x</name></expr> <range>in <expr><call><name>async_range</name><argument_list>(<argument><expr><literal type="number">10</literal></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><call><name>async_open</name><argument_list>(<argument><expr><name>filename</name></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file</name></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function><specifier>async</specifier> def <name>async_range</name><parameter_list>(<parameter><name>x</name></parameter>)</parameter_list><block>:<block_content>
     <yield>yield <expr><call><name>get_next</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></yield>
 </block_content></block></function>

--- a/test/parser/testsuite/string_py.py.xml
+++ b/test/parser/testsuite/string_py.py.xml
@@ -1,45 +1,45 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="string">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">"\
 a\
 "</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">"
 a
 "</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">""""""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">"""a"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">"""
 a
 """</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">"""a "b" c ""d"" e"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">"""
 a
 "b"
@@ -49,52 +49,52 @@ e
 """</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string" format="doxygen">"""!
 This is a string literal,
 formatted as doxygen.
 """</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">'a'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">'\
 a\
 '</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">'
 a
 '</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">''''''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">'''a'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">'''
 a
 '''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">'''a 'b' c ''d'' e'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>str</name> <operator>=</operator> <literal type="string">'''
 a
 'b'
@@ -104,54 +104,54 @@ e
 '''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string" format="doxygen">'''!
 This is a string literal,
 formatted as doxygen.
 '''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">"'"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">'"'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">"''"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">'""'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">"""'''"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">'''"""'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">"""''''''"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">'''""""""'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">"""'''a'''"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">'''"""b"""'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">"""
     This is a string literal,
@@ -160,7 +160,7 @@ formatted as doxygen.
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">"""
     Docstring example.
@@ -169,7 +169,7 @@ formatted as doxygen.
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring doxygen">"""!
     This is a string literal,
@@ -179,7 +179,7 @@ formatted as doxygen.
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">'''
     This is a string literal,
@@ -188,7 +188,7 @@ formatted as doxygen.
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">'''
     Docstring example.
@@ -197,7 +197,7 @@ formatted as doxygen.
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring doxygen">'''!
     This is a string literal,
@@ -207,7 +207,7 @@ formatted as doxygen.
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">"This is the real docstring."</literal></expr></expr_stmt>
     <expr_stmt><expr><literal type="string">b"""
@@ -217,7 +217,7 @@ formatted as doxygen.
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">'This is the real docstring.'</literal></expr></expr_stmt>
     <expr_stmt><expr><literal type="string">f'''
@@ -227,31 +227,31 @@ formatted as doxygen.
 </block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring">"""Docstring example."""</literal></expr>;</expr_stmt> <expr_stmt><expr><name>speed</name> <operator>=</operator> <literal type="number">50</literal></expr></expr_stmt></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring">"""This is the real docstring."""</literal></expr>;</expr_stmt> <expr_stmt><expr><literal type="string">'srcML'</literal></expr>;</expr_stmt> <expr_stmt><expr><name>speed</name> <operator>=</operator> <literal type="number">50</literal></expr></expr_stmt></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring doxygen">"""!Docstring doxygen example."""</literal></expr>;</expr_stmt> <expr_stmt><expr><name>speed</name> <operator>=</operator> <literal type="number">50</literal></expr></expr_stmt></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring">'''Docstring example.'''</literal></expr>;</expr_stmt> <expr_stmt><expr><name>speed</name> <operator>=</operator> <literal type="number">50</literal></expr></expr_stmt></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring">'''This is the real docstring.'''</literal></expr>;</expr_stmt> <expr_stmt><expr><literal type="string">"srcML"</literal></expr>;</expr_stmt> <expr_stmt><expr><name>speed</name> <operator>=</operator> <literal type="number">50</literal></expr></expr_stmt></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <class>class <name>Car</name><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring doxygen">'''!Docstring doxygen example.'''</literal></expr>;</expr_stmt> <expr_stmt><expr><name>speed</name> <operator>=</operator> <literal type="number">50</literal></expr></expr_stmt></block_content></block></class>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">"""
     This is a string literal,
@@ -260,7 +260,7 @@ formatted as doxygen.
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>, <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">"""
     This is a string literal,
@@ -269,7 +269,7 @@ formatted as doxygen.
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">"""
     Docstring example.
@@ -278,7 +278,7 @@ formatted as doxygen.
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring doxygen">"""!
     This is a string literal,
@@ -288,7 +288,7 @@ formatted as doxygen.
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>, <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring doxygen">"""!
     This is a string literal,
@@ -298,7 +298,7 @@ formatted as doxygen.
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">'''
     This is a string literal,
@@ -307,7 +307,7 @@ formatted as doxygen.
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>, <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">'''
     This is a string literal,
@@ -316,7 +316,7 @@ formatted as doxygen.
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">'''
     Docstring example.
@@ -325,7 +325,7 @@ formatted as doxygen.
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring doxygen">'''!
     This is a string literal,
@@ -335,7 +335,7 @@ formatted as doxygen.
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>, <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring doxygen">'''!
     This is a string literal,
@@ -345,7 +345,7 @@ formatted as doxygen.
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">"This is the real docstring."</literal></expr></expr_stmt>
     <expr_stmt><expr><literal type="string">r"""
@@ -355,7 +355,7 @@ formatted as doxygen.
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">'This is the real docstring.'</literal></expr></expr_stmt>
     <expr_stmt><expr><literal type="string">u'''
@@ -365,124 +365,124 @@ formatted as doxygen.
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring">"""Docstring example."""</literal></expr>;</expr_stmt> <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>, <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring">"""Docstring example."""</literal></expr>;</expr_stmt> <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring">"""This is the real docstring."""</literal></expr>;</expr_stmt> <expr_stmt><expr><literal type="string">'srcML'</literal></expr>;</expr_stmt> <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>, <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring">"""This is the real docstring."""</literal></expr>;</expr_stmt> <expr_stmt><expr><literal type="string">'srcML'</literal></expr>;</expr_stmt> <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring doxygen">"""!Docstring doxygen example."""</literal></expr>;</expr_stmt> <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>, <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring doxygen">"""!Docstring doxygen example."""</literal></expr>;</expr_stmt> <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring">'''Docstring example.'''</literal></expr>;</expr_stmt> <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>, <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring">'''Docstring example.'''</literal></expr>;</expr_stmt> <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring">'''This is the real docstring.'''</literal></expr>;</expr_stmt> <expr_stmt><expr><literal type="string">"srcML"</literal></expr>;</expr_stmt> <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>, <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring">'''This is the real docstring.'''</literal></expr>;</expr_stmt> <expr_stmt><expr><literal type="string">"srcML"</literal></expr>;</expr_stmt> <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring doxygen">'''!Docstring doxygen example.'''</literal></expr>;</expr_stmt> <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>sum</name><parameter_list>(<parameter><name>a</name><annotation>: <expr><name>int</name></expr></annotation></parameter>, <parameter><name>b</name><annotation>: <expr><name>int</name></expr></annotation></parameter>)</parameter_list><block>:<block_content> <expr_stmt><expr><literal type="string" format="docstring doxygen">'''!Docstring doxygen example.'''</literal></expr>;</expr_stmt> <return>return <expr><operator>(</operator><name>a</name> <operator>+</operator> <name>b</name><operator>)</operator></expr></return></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(
     <argument><expr><literal type="string">"String 1 "</literal>
     <literal type="string">"String 2 "</literal><literal type="string">"String 3"</literal></expr></argument>
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(
     <argument><expr><literal type="string">"\"String 1\" "</literal>
     <literal type="string">"\"String 2\" "</literal><literal type="string">"\"String 3\""</literal></expr></argument>
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(
     <argument><expr><literal type="string">"""String 1 """</literal>
     <literal type="string">"""String 2 """</literal><literal type="string">"""String 3"""</literal></expr></argument>
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(
     <argument><expr><literal type="string">"""\"String 1\" """</literal>
     <literal type="string">"""\"String 2\" """</literal><literal type="string">"""\"String 3\""""</literal></expr></argument>
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(
     <argument><expr><literal type="string">'String 1 '</literal>
     <literal type="string">'String 2 '</literal><literal type="string">'String 3'</literal></expr></argument>
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(
     <argument><expr><literal type="string">'\'String 1\' '</literal>
     <literal type="string">'\'String 2\' '</literal><literal type="string">'\'String 3\''</literal></expr></argument>
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(
     <argument><expr><literal type="string">'''String 1 '''</literal>
     <literal type="string">'''String 2 '''</literal><literal type="string">'''String 3'''</literal></expr></argument>
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(
     <argument><expr><literal type="string">'''\'String 1\' '''</literal>
     <literal type="string">'''\'String 2\' '''</literal><literal type="string">'''\'String 3\''''</literal></expr></argument>
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"""
 Hello
 World
 """</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><lambda>lambda <parameter><name>a</name></parameter>: <expr><literal type="string">f"""
 Func {a}
 """</literal></expr></lambda></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>example_one</name><parameter_list>()</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">""""a
     """</literal></expr></expr_stmt>
@@ -498,7 +498,7 @@ Func {a}
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>example_one</name><parameter_list>()</parameter_list><block>:<block_content>
     <expr_stmt><expr><literal type="string" format="docstring">''''a
     '''</literal></expr></expr_stmt>
@@ -514,295 +514,295 @@ Func {a}
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">b""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">b"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">b''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">b'a'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">b"b"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">b'b'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">b"""b"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">b'''b'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">B""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">B"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">B''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">B'a'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">B"B"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">B'B'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">B"""B"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">B'''B'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">f""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">f"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">f''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">f'a'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">f"f"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">f'f'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">f"""f"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">f'''f'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">F""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">F"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">F''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">F'a'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">F"F"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">F'F'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">F"""F"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">F'''F'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r'a'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r"r"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r'r'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r"""r"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r'''r'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">R""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">R"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">R''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">R'a'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">R"R"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">R'R'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">R"""R"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">R'''R'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">u""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">u"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">u''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">u'a'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">u"u"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">u'u'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">u"""u"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">u'''u'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r'a'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r"r"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r'r'</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r"""r"""</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r'''r'''</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">r"\a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">rf"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">rb"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">RF"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">RB"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">Rf"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">Rb"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">rF"a"</literal></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="string">rB"a"</literal></expr></expr_stmt>
 </unit>
 

--- a/test/parser/testsuite/switch_py.py.xml
+++ b/test/parser/testsuite/switch_py.py.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="switch">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><name>x</name></expr></condition><block>:<block_content>
     <case>case <expr><literal type="number">1</literal></expr><block>:<block_content>
         <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></case></block_content></block></switch>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><call><name>input</name><argument_list>()</argument_list></call></expr></condition><block>:<block_content>
     <case>case <expr><literal type="string">"/hi"</literal></expr><block>:<block_content>
         <expr_stmt><expr><call><name>call_hi</name><argument_list>()</argument_list></call></expr></expr_stmt>
@@ -17,7 +17,7 @@
 </block_content></block></case></block_content></block></switch>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><call><name>input</name><argument_list>()</argument_list></call><operator>.</operator><call><name>split</name><argument_list>()</argument_list></call></expr></condition><block>:<block_content>
     <case>case <expr><array>[<expr><literal type="string">'./'</literal></expr>]</array></expr><block>:<block_content>
         <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">'Home'</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
@@ -30,7 +30,7 @@
 </block_content></block></case></block_content></block></switch>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <switch>match <condition><expr><name>point</name></expr></condition><block>:<block_content>
     <case>case <expr><tuple>(<expr><literal type="number">0</literal></expr>, <expr><literal type="number">0</literal></expr>)</tuple></expr><block>:<block_content>
         <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Origin"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>

--- a/test/parser/testsuite/ternary_py.py.xml
+++ b/test/parser/testsuite/ternary_py.py.xml
@@ -1,67 +1,67 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="ternary">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>a</name> <ternary>if <condition><expr><name>b</name></expr></condition> <else>else <expr><name>c</name></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>x</name><argument_list>()</argument_list></call> <ternary>if <condition><expr><name>a</name> <operator>%</operator> <literal type="number">2</literal> <operator>==</operator> <literal type="number">0</literal></expr></condition> <else>else <expr><call><name>y</name><argument_list>()</argument_list></call></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">1</literal> <ternary>if <condition><expr><literal type="number">2</literal></expr></condition> <else>else <expr><literal type="number">3</literal> <ternary>if <condition><expr><literal type="number">4</literal></expr></condition> <else>else <expr><literal type="number">5</literal></expr></else></ternary></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>(</operator><literal type="number">1</literal> <ternary>if <condition><expr><literal type="number">2</literal></expr></condition> <else>else <expr><literal type="number">3</literal></expr></else></ternary><operator>)</operator> <ternary>if <condition><expr><literal type="number">4</literal></expr></condition> <else>else <expr><literal type="number">5</literal></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">1</literal> <ternary>if <condition><expr><operator>(</operator><literal type="number">2</literal> <ternary>if <condition><expr><literal type="number">3</literal></expr></condition> <else>else <expr><literal type="number">4</literal></expr></else></ternary><operator>)</operator></expr></condition> <else>else <expr><literal type="number">5</literal></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">1</literal> <ternary>if <condition><expr><literal type="number">2</literal></expr></condition> <else>else <expr><operator>(</operator><literal type="number">3</literal> <ternary>if <condition><expr><literal type="number">4</literal></expr></condition> <else>else <expr><literal type="number">5</literal></expr></else></ternary><operator>)</operator></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>value</name> <operator>=</operator> <name>a</name> <ternary>if <condition><expr><name>b</name></expr></condition> <else>else <expr><name>c</name></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"hello"</literal> <ternary>if <condition><expr><name>value</name></expr></condition> <else>else <expr><literal type="string">"goodbye"</literal></expr></else></ternary></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><operator>(</operator><name>a</name> <ternary>if <condition><expr><name>b</name></expr></condition> <else>else <expr><call><name>c</name><argument_list>()</argument_list></call></expr></else></ternary><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(<expr><name>a</name> <ternary>if <condition><expr><name>b</name></expr></condition> <else>else <expr><name>c</name></expr></else></ternary></expr>, <expr><name>d</name> <ternary>if <condition><expr><name>e</name></expr></condition> <else>else <expr><name>f</name></expr></else></ternary></expr>)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><array>[<expr><name>a</name> <ternary>if <condition><expr><name>b</name></expr></condition> <else>else <expr><name>c</name></expr></else></ternary></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><set>{<expr><name>a</name> <ternary>if <condition><expr><name>b</name></expr></condition> <else>else <expr><name>c</name></expr></else></ternary></expr>}</set></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><dictionary>{<expr><name>a</name></expr>: <expr><name>b</name> <ternary>if <condition><expr><name>c</name></expr></condition> <else>else <expr><name>d</name></expr></else></ternary></expr>}</dictionary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><name>val</name></expr> <comprehension><for>for <control><expr><name>val</name></expr> <range>in <expr><name>a</name></expr></range></control></for> <if>if <condition><expr><name>val</name> <operator>%</operator> <literal type="number">2</literal> <operator>==</operator> <literal type="number">0</literal></expr></condition></if></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <array>[<expr><name>val</name></expr> <comprehension><for>for <control><expr><name>val</name></expr> <range>in <expr><operator>(</operator><name>array</name> <ternary>if <condition><expr><literal type="boolean">True</literal></expr></condition> <else>else <expr><literal type="boolean">False</literal></expr></else></ternary><operator>)</operator></expr></range></control></for> <if>if <condition><expr><operator>(</operator><literal type="boolean">True</literal> <ternary>if <condition><expr><name>val</name> <operator>%</operator> <literal type="number">2</literal> <operator>==</operator> <literal type="number">0</literal></expr></condition> <else>else <expr><literal type="boolean">False</literal></expr></else></ternary><operator>)</operator></expr></condition></if></comprehension>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>example</name><argument_list>(
     <argument><name>one</name>=<expr><literal type="number">1</literal></expr></argument>,
     <argument><name>two</name>=<expr><operator>(</operator>
@@ -71,7 +71,7 @@
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>example</name> <operator>=</operator> <array>[
     <expr><array>[
         <expr><name>a</name> <ternary>if <condition><expr><name>a</name> <operator>is not</operator> <literal type="null">None</literal></expr></condition> <else>else <expr><call><name><name>sample</name><operator>.</operator><name>b</name></name><argument_list>(<argument><expr><literal type="number">2</literal></expr></argument>, <argument><expr><literal type="number">10</literal></expr></argument>, <argument><name>size</name>=<expr><tuple>(<expr><literal type="number">1</literal></expr>,)</tuple></expr></argument>)</argument_list></call><operator>.</operator><call><name>c</name><argument_list>()</argument_list></call></expr></else></ternary></expr>
@@ -81,21 +81,21 @@
 ]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>example</name> <operator>=</operator> <call><name>max</name><argument_list>(
     <argument><expr><operator>(</operator><call><name><name>a</name><operator>.</operator><name>b</name></name><argument_list>(<argument><expr><name>c</name></expr></argument>)</argument_list></call> <ternary>if <condition><expr><call><name>sample</name><argument_list>(<argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></condition> <else>else <expr><name>c</name></expr></else></ternary><operator>)</operator><operator>.</operator><name><name>array</name><index>[<expr><literal type="number">0</literal></expr>]</index></name></expr>
     <comprehension><for>for <control><expr><name>c</name></expr> <range>in <expr><name>d</name></expr></range></control></for></comprehension></argument>
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <for>for <control><expr><name>a</name></expr> <range>in <expr><name>array</name></expr></range></control><block>:<block_content>
     <expr_stmt><expr><name>b</name> <operator>=</operator> <name>b</name> <ternary>if <condition><expr><call><name>sample</name><argument_list>(<argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></condition> <else>else <expr><call><name><name>example</name><operator>.</operator><name>e</name></name><argument_list>(<argument><expr><name>b</name></expr></argument>)</argument_list></call></expr></else></ternary></expr></expr_stmt>
     <expr_stmt><expr><call><name><name>compound</name><operator>.</operator><name>name</name></name><argument_list>(<argument><expr><name><name>b</name><operator>.</operator><name>prop</name></name> <operator>is not</operator> <literal type="null">None</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></for>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>ternaries</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><name>example</name> <operator>=</operator> <call><name>max</name><argument_list>(
         <argument><expr><operator>(</operator><call><name><name>a</name><operator>.</operator><name>b</name></name><argument_list>(<argument><expr><name>c</name></expr></argument>)</argument_list></call> <ternary>if <condition><expr><call><name>sample</name><argument_list>(<argument><expr><name>c</name></expr></argument>, <argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></condition> <else>else <expr><name>c</name></expr></else></ternary><operator>)</operator><operator>.</operator><name><name>array</name><index>[<expr><literal type="number">0</literal></expr>]</index></name></expr>
@@ -108,7 +108,7 @@
 </block_content></block></for></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call> <ternary>if <condition><expr><name>a</name></expr></condition> <else>else <expr><call><name>call</name><argument_list>(
     <argument><expr><name>b</name></expr></argument>, <argument><expr><name>c</name></expr></argument>
 )</argument_list></call></expr></else></ternary></expr><block>:<block_content>
@@ -116,7 +116,7 @@
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call> <ternary>if <condition><expr><name>a</name></expr></condition> <else>else <expr><call><name>call</name><argument_list>(
     <argument><expr><name>b</name></expr></argument>, <argument><expr><operator>(</operator><name>c</name><operator>)</operator></expr></argument>
 )</argument_list></call></expr></else></ternary></expr><block>:<block_content>
@@ -124,7 +124,7 @@
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>operator_paren</name> <operator>=</operator> <operator>(</operator>
     <call><name>call_one</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call>
     <ternary>if <condition><expr><call><name>call_two</name><argument_list>(<argument><expr><name>b</name></expr></argument>, <argument><expr><name><name>c</name><operator>.</operator><name>d</name></name></expr></argument>)</argument_list></call></expr></condition>
@@ -132,7 +132,7 @@
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>operator_paren</name> <operator>=</operator> <operator>(</operator>
     <literal type="number">1</literal>
     <ternary>if <condition><expr><operator>(</operator><name>a</name> <operator>is</operator> <literal type="null">None</literal> <operator>or</operator> <name>a</name> <operator>&lt;</operator> <literal type="number">20</literal><operator>)</operator></expr></condition>
@@ -140,7 +140,7 @@
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><name>values</name> <operator>=</operator> <array>[
         <expr><literal type="null">None</literal> <ternary>if <condition><expr><name>a</name> <operator>is</operator> <literal type="null">None</literal></expr></condition> <else>else <expr><call><name>call_one</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr></else></ternary></expr>
@@ -152,7 +152,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <if_stmt><if>if <condition><expr><name>a</name></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>call_one</name><argument_list>()</argument_list></call><operator>.</operator><call><name>check</name><argument_list>(<argument><expr><literal type="string">"1"</literal></expr></argument>)</argument_list></call><operator>.</operator><call><name>check</name><argument_list>(<argument><expr><literal type="string">"2"</literal></expr></argument>)</argument_list></call><operator>.</operator><call><name>check</name><argument_list>(
         <argument><expr><literal type="string">"3"</literal> <ternary>if <condition><expr><operator>not</operator> <name>b</name></expr></condition> <else>else <expr><literal type="string">"4"</literal></expr></else></ternary></expr></argument>
@@ -160,7 +160,7 @@
 </block_content></block></if></if_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>expected</name> <operator>=</operator> <operator>(</operator>
     <name>a</name>
     <ternary>if <condition><expr><literal type="boolean">True</literal></expr></condition>
@@ -168,18 +168,18 @@
 <operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>inputs</name> <operator>=</operator> <name>a</name> <ternary>if <condition><expr><literal type="boolean">True</literal></expr></condition> <else>else <expr><call><name>call_one</name><argument_list>(<argument><expr><operator>*</operator><operator>(</operator><name>b</name> <operator>*</operator> <name>c</name><operator>)</operator></expr></argument>)</argument_list></call></expr></else></ternary></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>inputs</name> <operator>=</operator> <tuple>(
     <expr><name>a</name> <ternary>if <condition><expr><literal type="boolean">True</literal></expr></condition> <else>else <expr><call><name>call_one</name><argument_list>(<argument><expr><operator>*</operator><operator>(</operator><name>b</name> <operator>*</operator> <name>c</name><operator>)</operator></expr></argument>)</argument_list></call></expr></else></ternary></expr>,
     <expr><name>d</name></expr>
 )</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name><name>a</name><operator>.</operator><name>call_one</name></name><argument_list>(<argument><expr><literal type="null">None</literal> <ternary>if <condition><expr><name>b</name></expr></condition> <else>else <expr><call><name>call_two</name><argument_list>(<argument><expr><name>c</name></expr></argument>, <argument><expr><call><name><name>d</name><operator>.</operator><name>pop</name></name><argument_list>()</argument_list></call></expr></argument>)</argument_list></call> <ternary>if <condition><expr><name>e</name></expr></condition> <else>else <expr><literal type="number">1</literal></expr></else></ternary></expr></else></ternary></expr></argument>)</argument_list></call></expr></expr_stmt>
 </unit>
 

--- a/test/parser/testsuite/throw_py.py.xml
+++ b/test/parser/testsuite/throw_py.py.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="throw">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <throw>raise</throw>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <throw>raise <expr><literal type="number">0</literal></expr></throw>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <throw>raise <expr><name>Exception</name></expr></throw>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <throw>raise <expr><name>ZeroDivisionError</name></expr></throw>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <throw>raise <expr><call><name>Exception</name><argument_list>(<argument><expr><literal type="string">'error'</literal></expr></argument>)</argument_list></call></expr></throw>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <throw>raise <expr><name>RuntimeError</name></expr> <from>from <expr><name>ValueError</name></expr></from></throw>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <throw>raise <expr><name>RuntimeError</name></expr> <from>from <expr><literal type="null">None</literal></expr></from></throw>
 </unit>
 

--- a/test/parser/testsuite/try_py.py.xml
+++ b/test/parser/testsuite/try_py.py.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="try">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except<block>:<block_content>
@@ -9,7 +9,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content>
@@ -17,7 +17,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <expr><name>ZeroDivisionError</name></expr> <alias>as <expr><name>e</name></expr></alias><block>:<block_content>
@@ -25,7 +25,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <expr><name>ValueError</name></expr> <alias>as <expr><name>e</name></expr></alias><block>:<block_content>
@@ -37,7 +37,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except* <expr><name>NameError</name></expr> <alias>as <expr><name>e</name></expr></alias><block>:<block_content>
@@ -47,7 +47,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <pass>pass</pass>
 </block_content></block><catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content>
@@ -57,7 +57,7 @@
 </block_content></block></else></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <pass>pass</pass>
 </block_content></block><catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content>
@@ -69,7 +69,7 @@
 </block_content></block></else></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Valid"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block><finally>finally<block>:<block_content>
@@ -77,7 +77,7 @@
 </block_content></block></finally></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block><catch>except<block>:<block_content>
@@ -87,7 +87,7 @@
 </block_content></block></finally></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Try"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block><catch>except<block>:<block_content>
@@ -99,7 +99,7 @@
 </block_content></block></finally></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"Try"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block><catch>except <expr><name>NameError</name></expr> <alias>as <expr><name>e</name></expr></alias><block>:<block_content>
@@ -115,7 +115,7 @@
 </block_content></block></finally></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <expr><tuple>(<expr><name>ValueError</name></expr>, <expr><name>ZeroDivisionError</name></expr>)</tuple></expr><block>:<block_content>
@@ -123,7 +123,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <expr><tuple>(<expr><name>ValueError</name></expr>, <expr><name>ZeroDivisionError</name></expr>)</tuple></expr> <alias>as <expr><name>e</name></expr></alias><block>:<block_content>
@@ -131,7 +131,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <alias><expr><name>ZeroDivisionError</name></expr>, <name>e</name></alias><block>:<block_content>
@@ -139,7 +139,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <alias><expr><tuple>(<expr><name>ZeroDivisionError</name></expr>, <expr><name>ValueError</name></expr>, <expr><name>TypeError</name></expr>)</tuple></expr>, <name>e</name></alias><block>:<block_content>
@@ -147,7 +147,7 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content>
     <expr_stmt><expr><literal type="number">1</literal><operator>/</operator><literal type="number">0</literal></expr></expr_stmt>
 </block_content></block><catch>except <alias><expr><operator>(</operator><name>ZeroDivisionError</name><operator>)</operator></expr>, <operator>(</operator><name>e</name><operator>)</operator></alias><block>:<block_content>
@@ -155,48 +155,48 @@
 </block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>x</name> <operator>/</operator> <name>y</name></expr></expr_stmt></block_content></block>
 <catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"ZeroDivisionError"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>x</name> <operator>/</operator> <name>y</name></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>result</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block>
 <catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"error:"</literal></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"ZeroDivisionError"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></catch></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>x</name> <operator>/</operator> <name>y</name></expr></expr_stmt></block_content></block>
 <catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"ZeroDivisionError"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></catch>
 <else>else<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>result</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>x</name> <operator>/</operator> <name>y</name></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>result</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block>
 <catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"error:"</literal></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"ZeroDivisionError"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></catch>
 <else>else<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"result:"</literal></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>result</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>x</name> <operator>/</operator> <name>y</name></expr></expr_stmt></block_content></block>
 <catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"ZeroDivisionError"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></catch>
 <finally>finally<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"finally"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></finally></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>x</name> <operator>/</operator> <name>y</name></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>result</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block>
 <catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"error:"</literal></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"ZeroDivisionError"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></catch>
 <finally>finally<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"finally"</literal></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>result</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></finally></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>x</name> <operator>/</operator> <name>y</name></expr></expr_stmt></block_content></block>
 <catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"ZeroDivisionError"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></catch>
 <else>else<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>result</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else>
 <finally>finally<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"finally"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></finally></try>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <try>try<block>:<block_content> <expr_stmt><expr><name>result</name> <operator>=</operator> <name>x</name> <operator>/</operator> <name>y</name></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>result</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block>
 <catch>except <expr><name>ZeroDivisionError</name></expr><block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"error:"</literal></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"ZeroDivisionError"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></catch>
 <else>else<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"result:"</literal></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>result</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else>

--- a/test/parser/testsuite/tuple_py.py.xml
+++ b/test/parser/testsuite/tuple_py.py.xml
@@ -1,146 +1,146 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="tuple">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>()</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(,)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(<expr><literal type="number">1</literal></expr>,)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(<expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>,)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(<expr><literal type="number">1</literal></expr>,<expr><literal type="number">2</literal></expr>,<expr><literal type="number">3</literal></expr>)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(<expr><literal type="number">1</literal></expr>,<expr><literal type="number">2</literal></expr>,<expr><literal type="number">3</literal></expr>,)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(<expr><call><name>b</name><argument_list>()</argument_list></call></expr>, <expr><call><name>c</name><argument_list>()</argument_list></call></expr>)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>x</name> <operator>=</operator> <tuple>(<expr><literal type="string">"hello"</literal></expr>,<expr><literal type="string">"world"</literal></expr>)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(<expr><tuple>()</tuple></expr>,<expr><tuple>()</tuple></expr>)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(<expr><operator>(</operator><name>d</name><operator>)</operator></expr>, <expr><operator>(</operator><name>e</name><operator>)</operator></expr>)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>empty</name> <operator>=</operator> <tuple>()</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>empty</name> <operator>=</operator> <operator>(</operator><tuple>()</tuple><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>empty</name> <operator>=</operator> <operator>(</operator><operator>(</operator><tuple>()</tuple><operator>)</operator><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(<expr><tuple>(<expr><literal type="number">1</literal></expr>,<expr><literal type="number">2</literal></expr>)</tuple></expr>,<expr><tuple>(<expr><literal type="number">3</literal></expr>,<expr><literal type="number">4</literal></expr>)</tuple></expr>,<expr><tuple>(<expr><literal type="number">5</literal></expr>,<expr><literal type="number">6</literal></expr>)</tuple></expr>)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>empty</name> <operator>=</operator> <array>[<expr><tuple>()</tuple></expr>]</array></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>inputs</name> <operator>=</operator> <tuple>(
     <expr><name>a</name> <ternary>if <condition><expr><literal type="boolean">True</literal></expr></condition> <else>else <expr><call><name>call_one</name><argument_list>(<argument><expr><literal type="number">0</literal></expr></argument>, <argument><expr><literal type="number">1</literal></expr></argument>)</argument_list></call></expr></else></ternary></expr>,
     <expr><name>b</name></expr>
 )</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple><expr><literal type="number">1</literal></expr>,</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple><expr><literal type="number">1</literal></expr>,<expr><literal type="number">2</literal></expr></tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple><expr><literal type="number">1</literal></expr>,<expr><literal type="number">2</literal></expr>,</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple><expr><name>x</name></expr>, <expr><name>y</name></expr>, <expr><name>z</name></expr></tuple> <operator>=</operator> <tuple><expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr>, <expr><literal type="number">3</literal></expr></tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple><expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr>,</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple><expr><literal type="number">1</literal></expr>,<expr><literal type="number">2</literal></expr>,<expr><tuple>(<expr><literal type="number">3</literal></expr>,<expr><literal type="number">4</literal></expr>)</tuple></expr></tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>, <expr><name>c</name></expr>)</tuple> <operator>=</operator> <tuple>(<expr><literal type="number">4</literal></expr>, <expr><literal type="number">5</literal></expr>, <expr><literal type="number">6</literal></expr>)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><tuple>(<expr><call><name>a</name><argument_list>(<argument><expr><tuple>(<expr><name>x</name></expr>, <expr><name>y</name></expr>)</tuple></expr></argument>, <argument><expr><name>z</name></expr></argument>)</argument_list></call></expr>, <expr><name>b</name></expr>)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>result</name> <operator>=</operator> <tuple>(<expr><name>a</name></expr>, <expr><operator>*</operator><array>[<expr><name>b</name></expr> <comprehension><for>for <control><expr><name>_</name></expr> <range>in <expr><call><name>c</name><argument_list>(<argument><expr><call><name>d</name><argument_list>(<argument><expr><name>e</name></expr></argument>)</argument_list></call></expr></argument>)</argument_list></call></expr></range></control></for></comprehension>]</array></expr>)</tuple></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>construct</name> <operator>=</operator> <operator>(</operator><operator>(</operator><tuple>(<expr><call><name>a</name><argument_list>()</argument_list></call></expr>, <expr><call><name>b</name><argument_list>()</argument_list></call></expr>)</tuple><operator>)</operator><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><name>construct</name> <operator>=</operator> <operator>(</operator><tuple>(<expr><operator>(</operator><name>a</name><operator>)</operator></expr>, <expr><operator>(</operator><name>b</name><operator>)</operator></expr>, <expr><name>c</name></expr>)</tuple><operator>)</operator></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>keyword_arguments</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>, <parameter><name>c</name></parameter>, <parameter><name>d</name></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><tuple><expr><call><name><name>a</name><operator>.</operator><name>sample</name></name><argument_list>(<argument><expr><name>b</name></expr></argument>, <argument><name>example</name>=<expr><name>c</name></expr></argument>)</argument_list></call></expr>, <expr><call><name><name>a</name><operator>.</operator><name>sample</name></name><argument_list>(<argument><expr><name>d</name></expr></argument>)</argument_list></call></expr></tuple></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>keyword_arguments</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>, <parameter><name>c</name></parameter>, <parameter><name>d</name></parameter>, <parameter><name>e</name></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><tuple><expr><call><name><name>a</name><operator>.</operator><name>sample</name></name><argument_list>(<argument><expr><name>b</name></expr></argument>, <argument><name>example</name>=<expr><name>c</name></expr></argument>)</argument_list></call></expr>, <expr><call><name><name>a</name><operator>.</operator><name>sample</name></name><argument_list>(<argument><expr><name>d</name></expr></argument>, <argument><name>example</name>=<expr><name>e</name></expr></argument>)</argument_list></call></expr></tuple></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>named_arguments</name><parameter_list>(<parameter><name>a</name></parameter>, <parameter><name>b</name></parameter>)</parameter_list><block>:<block_content>
     <return>return <expr><tuple><expr><call><name>call_one</name><argument_list>(<argument><expr><name>type</name><operator>=</operator><name>a</name></expr></argument>)</argument_list></call></expr>, <expr><call><name>call_one</name><argument_list>(<argument><expr><name>type</name><operator>=</operator><name>b</name></expr></argument>)</argument_list></call></expr></tuple></expr></return>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>a</name></expr></alias><block>:<block_content>
     <expr_stmt><expr><tuple><expr><name>indices</name></expr>, <expr><name>values</name></expr></tuple> <operator>=</operator> <call><name><name>a</name><operator>.</operator><name>zip</name></name><argument_list>()</argument_list></call></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>a</name></expr></alias><block>:<block_content>
     <expr_stmt><expr><tuple><expr><name>indices</name></expr>, <expr><name>values</name></expr></tuple> <operator>=</operator> <call><name><name>a</name><operator>.</operator><name>zip</name></name><argument_list>()</argument_list></call></expr></expr_stmt>
 </block_content></block></with>

--- a/test/parser/testsuite/typedef_py.py.xml
+++ b/test/parser/testsuite/typedef_py.py.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="typedef">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <typedef>type <name>a</name> = <expr><name>int</name></expr></typedef>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <typedef>type <name>Vector</name> = <expr><name><name>list</name><index>[<expr><name>float</name></expr>]</index></name></expr></typedef>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <typedef>type <name>Address</name> = <expr><name><name>tuple</name><index>[<expr><name>str</name></expr>, <expr><name>int</name></expr>]</index></name></expr></typedef>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <typedef>type <name><name>ListOrSet</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list></name> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>T</name></expr>]</index></name></expr></typedef>
 </unit>
 

--- a/test/parser/testsuite/while_py.py.xml
+++ b/test/parser/testsuite/while_py.py.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="while">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><name>loop</name></expr></condition><block>:<block_content>
     <expr_stmt><expr><call><name>check</name><argument_list>()</argument_list></call></expr></expr_stmt>
 </block_content></block></while>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><name>loop</name></expr></condition><block>:<block_content>
     <break>break</break>
 </block_content></block><else>else<block>:<block_content>
@@ -15,20 +15,20 @@
 </block_content></block></else></while>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><name>x</name> <operator>&lt;</operator> <literal type="number">10</literal></expr></condition><block>:<block_content> <expr_stmt><expr><name>x</name> <operator>+=</operator> <literal type="number">1</literal></expr></expr_stmt></block_content></block></while>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><name>x</name> <operator>&lt;</operator> <literal type="number">10</literal></expr></condition><block>:<block_content> <expr_stmt><expr><name>x</name> <operator>+=</operator> <literal type="number">1</literal></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></while>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><name>x</name> <operator>&lt;</operator> <literal type="number">10</literal></expr></condition><block>:<block_content> <expr_stmt><expr><name>x</name> <operator>+=</operator> <literal type="number">1</literal></expr></expr_stmt></block_content></block>
 <else>else<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"srcML\n"</literal></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else></while>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <while>while <condition><expr><name>x</name> <operator>&lt;</operator> <literal type="number">10</literal></expr></condition><block>:<block_content> <expr_stmt><expr><name>x</name> <operator>+=</operator> <literal type="number">1</literal></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block>
 <else>else<block>:<block_content> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"result:"</literal></expr></argument>)</argument_list></call></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></else></while>
 </unit>

--- a/test/parser/testsuite/with_py.py.xml
+++ b/test/parser/testsuite/with_py.py.xml
@@ -1,259 +1,259 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="with">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test1.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr>, <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test2.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file</name></expr></alias><block>:<block_content>
     <expr_stmt><expr><call><name><name>file</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"Hello World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test1.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file1</name></expr></alias>, <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test2.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file2</name></expr></alias><block>:<block_content>
     <expr_stmt><expr><call><name><name>file1</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"Hello"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
     <expr_stmt><expr><call><name><name>file2</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test1.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file1</name></expr></alias>, <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test2.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr><block>:<block_content>
     <expr_stmt><expr><call><name><name>file1</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"Hello"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test1.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr>, <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test2.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file2</name></expr></alias><block>:<block_content>
     <expr_stmt><expr><call><name><name>file2</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><operator>(</operator><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call><operator>)</operator></expr><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><tuple>(<expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test1.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr>, <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test2.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr>)</tuple></expr><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><operator>(</operator><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call> <alias>as <expr><name>file</name></expr></alias><operator>)</operator></expr><block>:<block_content>
     <expr_stmt><expr><call><name><name>file</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"Hello World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><tuple>(<expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test1.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file1</name></expr></alias>, <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test2.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file2</name></expr></alias>)</tuple></expr><block>:<block_content>
     <expr_stmt><expr><call><name><name>file1</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"Hello"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
     <expr_stmt><expr><call><name><name>file2</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><tuple>(<expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test1.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file1</name></expr></alias>, <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test2.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr>)</tuple></expr><block>:<block_content>
     <expr_stmt><expr><call><name><name>file1</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"Hello"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><tuple>(<expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test1.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr>, <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test2.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file2</name></expr></alias>)</tuple></expr><block>:<block_content>
     <expr_stmt><expr><call><name><name>file2</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file</name></expr></alias><block>:<block_content>
     <expr_stmt><expr><call><name><name>file</name><operator>.</operator><name>write</name></name><argument_list>(<argument><expr><literal type="string">"Hello World"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">"python.txt"</literal></expr></argument>, <argument><expr><literal type="string">"w"</literal></expr></argument>)</argument_list></call></expr><block>:<block_content> <pass>pass</pass></block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">"python.txt"</literal></expr></argument>, <argument><expr><literal type="string">"w"</literal></expr></argument>)</argument_list></call></expr><block>:<block_content> <expr_stmt><expr><name>a</name> <operator>=</operator> <literal type="number">1</literal></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">"python.txt"</literal></expr></argument>, <argument><expr><literal type="string">"w"</literal></expr></argument>)</argument_list></call></expr><block>:<block_content> <pass>pass</pass></block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">"python.txt"</literal></expr></argument>, <argument><expr><literal type="string">"w"</literal></expr></argument>)</argument_list></call></expr><block>:<block_content> <expr_stmt><expr><name>a</name> <operator>=</operator> <literal type="number">1</literal></expr>;</expr_stmt> <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><name>a</name></expr></argument>)</argument_list></call></expr></expr_stmt></block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><array>[<expr><name>a</name></expr>, <expr><name>b</name></expr>]</array></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test1.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file1</name></expr></alias>, <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test2.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file2</name></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name><name>joblib</name><operator>.</operator><name>parallel_backend</name></name><argument_list>(<argument><expr><literal type="string">"testing"</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr></alias>, <expr><call><name><name>joblib</name><operator>.</operator><name>parallel_backend</name></name><argument_list>(<argument><expr><literal type="string">"testing"</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><tuple>(<expr><name>c</name></expr>, <expr><name>d</name></expr>)</tuple></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name><name>joblib</name><operator>.</operator><name>parallel_backend</name></name><argument_list>(<argument><expr><literal type="string">"testing"</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><array>[<expr><name>a</name></expr>, <expr><name>b</name></expr>]</array></expr></alias>, <expr><call><name><name>joblib</name><operator>.</operator><name>parallel_backend</name></name><argument_list>(<argument><expr><literal type="string">"testing"</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><array>[<expr><name>c</name></expr>, <expr><name>d</name></expr>]</array></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><array>[<expr><name>a</name></expr>, <expr><name>b</name></expr>]</array></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test1.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file1</name></expr></alias>, <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test2.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><name>file2</name></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><call><name><name>joblib</name><operator>.</operator><name>parallel_backend</name></name><argument_list>(<argument><expr><literal type="string">"testing"</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><tuple>(<expr><name>a</name></expr>, <expr><name>b</name></expr>)</tuple></expr></alias>, <expr><call><name><name>joblib</name><operator>.</operator><name>parallel_backend</name></name><argument_list>(<argument><expr><literal type="string">"testing"</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><tuple>(<expr><name>c</name></expr>, <expr><name>d</name></expr>)</tuple></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><call><name><name>joblib</name><operator>.</operator><name>parallel_backend</name></name><argument_list>(<argument><expr><literal type="string">"testing"</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><array>[<expr><name>a</name></expr>, <expr><name>b</name></expr>]</array></expr></alias>, <expr><call><name><name>joblib</name><operator>.</operator><name>parallel_backend</name></name><argument_list>(<argument><expr><literal type="string">"testing"</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><array>[<expr><name>c</name></expr>, <expr><name>d</name></expr>]</array></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><name><name>f</name><operator>.</operator><name>g</name><operator>.</operator><name>h</name></name></expr> <alias>as <expr><tuple>(<expr><name><name>a</name><operator>.</operator><name>a1</name></name></expr>, <expr><name><name>b</name><operator>.</operator><name>b1</name></name></expr>)</tuple></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><name><name>f</name><operator>.</operator><name>g</name><operator>.</operator><name>h</name></name></expr> <alias>as <expr><array>[<expr><name><name>a</name><operator>.</operator><name>a1</name></name></expr>, <expr><name><name>b</name><operator>.</operator><name>b1</name></name></expr>]</array></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><name><name>f</name><operator>.</operator><name>g</name><operator>.</operator><name>h</name></name></expr> <alias>as <expr><name><name>a</name><operator>.</operator><name>a1</name></name></expr></alias>, <expr><name><name>f</name><operator>.</operator><name>i</name><operator>.</operator><name>j</name></name></expr> <alias>as <expr><name><name>b</name><operator>.</operator><name>b1</name></name></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><name><name>f</name><operator>.</operator><name>g</name><operator>.</operator><name>h</name></name></expr> <alias>as <expr><tuple>(<expr><name><name>a</name><operator>.</operator><name>a1</name></name></expr>, <expr><name><name>b</name><operator>.</operator><name>b1</name></name></expr>)</tuple></expr></alias>, <expr><name><name>f</name><operator>.</operator><name>i</name><operator>.</operator><name>j</name></name></expr> <alias>as <expr><tuple>(<expr><name><name>c</name><operator>.</operator><name>c1</name></name></expr>, <expr><name><name>d</name><operator>.</operator><name>d1</name></name></expr>)</tuple></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><name><name>f</name><operator>.</operator><name>g</name><operator>.</operator><name>h</name></name></expr> <alias>as <expr><array>[<expr><name><name>a</name><operator>.</operator><name>a1</name></name></expr>, <expr><name><name>b</name><operator>.</operator><name>b1</name></name></expr>]</array></expr></alias>, <expr><name><name>f</name><operator>.</operator><name>i</name><operator>.</operator><name>j</name></name></expr> <alias>as <expr><array>[<expr><name><name>c</name><operator>.</operator><name>c1</name></name></expr>, <expr><name><name>d</name><operator>.</operator><name>d1</name></name></expr>]</array></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><name><name>f</name><operator>.</operator><name>g</name><operator>.</operator><name>h</name></name></expr> <alias>as <expr><tuple>(<expr><name><name>a</name><operator>.</operator><name>a1</name></name></expr>, <expr><name><name>b</name><operator>.</operator><name>b1</name></name></expr>)</tuple></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><name><name>f</name><operator>.</operator><name>g</name><operator>.</operator><name>h</name></name></expr> <alias>as <expr><array>[<expr><name><name>a</name><operator>.</operator><name>a1</name></name></expr>, <expr><name><name>b</name><operator>.</operator><name>b1</name></name></expr>]</array></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><name><name>f</name><operator>.</operator><name>g</name><operator>.</operator><name>h</name></name></expr> <alias>as <expr><name><name>a</name><operator>.</operator><name>a1</name></name></expr></alias>, <expr><name><name>f</name><operator>.</operator><name>i</name><operator>.</operator><name>j</name></name></expr> <alias>as <expr><name><name>b</name><operator>.</operator><name>b1</name></name></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><name><name>f</name><operator>.</operator><name>g</name><operator>.</operator><name>h</name></name></expr> <alias>as <expr><tuple>(<expr><name><name>a</name><operator>.</operator><name>a1</name></name></expr>, <expr><name><name>b</name><operator>.</operator><name>b1</name></name></expr>)</tuple></expr></alias>, <expr><name><name>f</name><operator>.</operator><name>i</name><operator>.</operator><name>j</name></name></expr> <alias>as <expr><tuple>(<expr><name><name>c</name><operator>.</operator><name>c1</name></name></expr>, <expr><name><name>d</name><operator>.</operator><name>d1</name></name></expr>)</tuple></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><name><name>f</name><operator>.</operator><name>g</name><operator>.</operator><name>h</name></name></expr> <alias>as <expr><array>[<expr><name><name>a</name><operator>.</operator><name>a1</name></name></expr>, <expr><name><name>b</name><operator>.</operator><name>b1</name></name></expr>]</array></expr></alias>, <expr><name><name>f</name><operator>.</operator><name>i</name><operator>.</operator><name>j</name></name></expr> <alias>as <expr><array>[<expr><name><name>c</name><operator>.</operator><name>c1</name></name></expr>, <expr><name><name>d</name><operator>.</operator><name>d1</name></name></expr>]</array></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><name>example</name></expr><block>:<block_content>
     <expr_stmt><expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr></tuple> <operator>=</operator> <tuple><expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr></tuple></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><operator>(</operator><name>a</name><operator>)</operator></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><name>example</name></expr><block>:<block_content>
     <expr_stmt><expr><tuple><expr><name>a</name></expr>, <expr><name>b</name></expr></tuple> <operator>=</operator> <tuple><expr><literal type="number">1</literal></expr>, <expr><literal type="number">2</literal></expr></tuple></expr></expr_stmt>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with><specifier>async</specifier> with <expr><call><name>open</name><argument_list>(<argument><expr><literal type="string">'test.txt'</literal></expr></argument>,<argument><expr><literal type="string">'w'</literal></expr></argument>)</argument_list></call></expr> <alias>as <expr><operator>(</operator><name>a</name><operator>)</operator></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>call_one</name><argument_list>()</argument_list></call></expr> <alias>as <expr><call><name>list</name><argument_list>(<argument><expr><call><name><name>a</name><operator>.</operator><name>values</name></name><argument_list>()</argument_list></call></expr></argument>)</argument_list></call><index>[<expr><literal type="number">0</literal></expr>]</index><index>[<expr><literal type="number">1</literal></expr>]</index></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <with>with <expr><call><name>call_one</name><argument_list>()</argument_list></call></expr> <alias>as <expr><tuple>(<expr><call><name>list</name><argument_list>(<argument><expr><call><name><name>a</name><operator>.</operator><name>values</name></name><argument_list>()</argument_list></call></expr></argument>)</argument_list></call><index>[<expr><literal type="number">0</literal></expr>]</index><index>[<expr><literal type="number">2</literal></expr>]</index></expr>, <expr><call><name>list</name><argument_list>(<argument><expr><call><name><name>b</name><operator>.</operator><name>values</name></name><argument_list>()</argument_list></call></expr></argument>)</argument_list></call><index>[<expr><literal type="number">0</literal></expr>]</index><index>[<expr><literal type="number">1</literal></expr>]</index></expr>, <expr><call><name>list</name><argument_list>(<argument><expr><call><name><name>c</name><operator>.</operator><name>values</name></name><argument_list>()</argument_list></call></expr></argument>)</argument_list></call><index>[<expr><literal type="number">0</literal></expr>]</index><index>[<expr><literal type="number">0</literal></expr>]</index></expr>)</tuple></expr></alias><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></with>

--- a/test/parser/testsuite/yield_py.py.xml
+++ b/test/parser/testsuite/yield_py.py.xml
@@ -1,72 +1,72 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <unit xmlns="http://www.srcML.org/srcML/src" language="Python" url="yield">
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>generator</name><parameter_list>()</parameter_list><block>:<block_content>
     <yield>yield</yield>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>generator</name><parameter_list>()</parameter_list><block>:<block_content>
     <yield>yield <expr><literal type="number">1</literal></expr></yield>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>generator</name><parameter_list>()</parameter_list><block>:<block_content>
     <yield>yield <expr><literal type="number">1</literal></expr></yield>
     <yield>yield <expr><literal type="number">2</literal></expr></yield>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>generator</name><parameter_list>(<parameter><name>x</name></parameter>)</parameter_list><block>:<block_content>
     <for>for <control><expr><name>i</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
         <yield>yield <expr><name>i</name></expr></yield>
 </block_content></block></for></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>generator</name><parameter_list>(<parameter><name>x</name></parameter>)</parameter_list><block>:<block_content>
     <yield type="from">yield from <expr><call><name>range</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></yield>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>generator</name><parameter_list>(<parameter><name>x</name></parameter>)</parameter_list><block>:<block_content>
     <if_stmt><if>if <condition><expr><operator>(</operator><yield>yield <expr><name>x</name></expr></yield><operator>)</operator></expr></condition><block>:<block_content>
         <pass>pass</pass>
 </block_content></block></if></if_stmt></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>generator</name><parameter_list>()</parameter_list><block>:<block_content>
     <expr_stmt><expr><name>val</name> <operator>=</operator> <yield>yield</yield></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>generator</name><parameter_list>(<parameter><name>x</name></parameter>)</parameter_list><block>:<block_content>
     <for>for <control><expr><name>i</name></expr> <range>in <expr><call><name>range</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></range></control><block>:<block_content>
         <expr_stmt><expr><name>val</name> <operator>=</operator> <yield>yield <expr><name>i</name></expr></yield></expr></expr_stmt>
 </block_content></block></for></block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <function>def <name>generator</name><parameter_list>(<parameter><name>x</name></parameter>)</parameter_list><block>:<block_content>
     <expr_stmt><expr><name>arr</name> <operator>=</operator> <yield type="from">yield from <expr><call><name>range</name><argument_list>(<argument><expr><name>x</name></expr></argument>)</argument_list></call></expr></yield></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>call_one</name><argument_list>(
     <argument><expr><call><name>call_two</name><argument_list>(<argument><expr><operator>(</operator><lambda>lambda: <expr><operator>(</operator><yield>yield <expr><name>a</name></expr></yield><operator>)</operator></expr></lambda><operator>)</operator></expr></argument>)</argument_list></call></expr></argument>,
     <argument><expr><name>a</name></expr></argument>,
 )</argument_list></call></expr></expr_stmt>
 </unit>
 
-<unit revision="1.1.0" language="Python">
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>call_one</name><argument_list>(
     <argument><expr><call><name>call_two</name><argument_list>(<argument><expr><operator>(</operator><lambda>lambda: <expr><operator>(</operator><yield type="from">yield from <expr><name>a</name></expr></yield><operator>)</operator></expr></lambda><operator>)</operator></expr></argument>)</argument_list></call></expr></argument>,
     <argument><expr><name>a</name></expr></argument>,


### PR DESCRIPTION
Changing revision="1.1.0" to revision="1.0.0" in the Python client tests.