### PR TITLE
Fix bug with soft keyword "type" marked as a statement

### DIFF
--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -1197,18 +1197,21 @@ start_python[] {
         }
 
         // invoke the table to handle keywords and duplex keywords
-        // do not mark "type()" as a "type" statement, but as a function call
-        if (inMode(MODE_STATEMENT) && (LA(1) != PY_TYPE || next_token() != LPAREN)) {
+        if (inMode(MODE_STATEMENT)) {
             auto token = LA(1);
+            bool is_type_stmt = (token == PY_TYPE && (next_token() == NAME || identifier_list_tokens_set.member(next_token())));
+
             if (duplex_keyword_set.member((unsigned int) LA(1))) {
                 const auto lookup = duplexKeywords[token + (next_token() << 8)];
                 if (lookup)
                     token = lookup;
             }
 
-            const auto& rule = python_rules[token];
-            if (rule.elementToken && processRule(rule)) {
-                return;
+            if (LA(1) != PY_TYPE || is_type_stmt) {
+                const auto& rule = python_rules[token];
+                if (rule.elementToken && processRule(rule)) {
+                    return;
+                }
             }
         }
 

--- a/test/parser/testsuite/keyword_as_name_py.py.xml
+++ b/test/parser/testsuite/keyword_as_name_py.py.xml
@@ -102,7 +102,7 @@
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<expr_stmt><expr><name>typedef</name> <operator>=</operator> <literal type="string">"typedef"</literal></expr></expr_stmt>
+<expr_stmt><expr><name>type</name> <operator>=</operator> <literal type="string">"type"</literal></expr></expr_stmt>
 </unit>
 
 <unit revision="1.0.0" language="Python">
@@ -187,6 +187,10 @@
 
 <unit revision="1.0.0" language="Python">
 <expr_stmt><expr><call><name>type</name><argument_list>()</argument_list></call></expr></expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="Python">
+<expr_stmt><expr><tuple><expr><name>type</name></expr>, <expr><name>params</name></expr></tuple> <operator>=</operator> <tuple><expr><literal type="number">0</literal></expr>, <expr><literal type="number">1</literal></expr></tuple></expr></expr_stmt>
 </unit>
 
 <unit revision="1.0.0" language="Python">


### PR DESCRIPTION
In Python, `type` is a soft keyword, but there is also a `type` statement.

This fix (should) ensure that `type` soft-keyword cases are _not_ marked as `type` statements.

Examples (all these are expression statements):
```py
type = None
type = results[0].get('type')
type, params = 0, 1
```