### PR TITLE
Add Python comments to skip tokens set

### DIFF
--- a/src/parser/srcml_bitset_token_sets.hpp
+++ b/src/parser/srcml_bitset_token_sets.hpp
@@ -99,7 +99,8 @@ token_set(srcMLParser, modifier_tokens_set,
 
 token_set(srcMLParser, skip_tokens_set,
     srcMLParser::WS, srcMLParser::CONTROL_CHAR, srcMLParser::EOL_BACKSLASH, srcMLParser::BLOCK_COMMENT_START, srcMLParser::BLOCK_COMMENT_END, srcMLParser::LINE_COMMENT_END, srcMLParser::COMMENT_TEXT,
-    srcMLParser::LINE_COMMENT_START, srcMLParser::JAVADOC_COMMENT_START, srcMLParser::DOXYGEN_COMMENT_START, srcMLParser::LINE_DOXYGEN_COMMENT_START, srcMLParser::EOL, srcMLParser::WHOLE_COMMENT, srcMLParser::WS_EOL
+    srcMLParser::LINE_COMMENT_START, srcMLParser::JAVADOC_COMMENT_START, srcMLParser::DOXYGEN_COMMENT_START, srcMLParser::LINE_DOXYGEN_COMMENT_START, srcMLParser::EOL, srcMLParser::WHOLE_COMMENT,
+    srcMLParser::HASHTAG_COMMENT_START, srcMLParser::HASHTAG_COMMENT_END, srcMLParser::HASHBANG_COMMENT_START, srcMLParser::HASHBANG_COMMENT_END, srcMLParser::WS_EOL
 )
 
 token_set(srcMLParser, class_tokens_set,


### PR DESCRIPTION
Includes:
```
srcMLParser::HASHTAG_COMMENT_START
srcMLParser::HASHTAG_COMMENT_END
srcMLParser::HASHBANG_COMMENT_START
srcMLParser::HASHBANG_COMMENT_END
```