### PR TITLE
Allow "J" as part of a Python complex literal

### DIFF
--- a/src/parser/TextLexer.g
+++ b/src/parser/TextLexer.g
@@ -132,7 +132,7 @@ CONSTANTS :
         'i' { $setType(COMPLEX_NUMBER); } |
 
         { inLanguage(LANGUAGE_PYTHON) }?
-        'j' { $setType(COMPLEX_NUMBER); }
+        ('j' | 'J') { $setType(COMPLEX_NUMBER); }
     )*
     (options { greedy = true; } : NAME)*
     {

--- a/test/parser/testsuite/literal_py.py.xml
+++ b/test/parser/testsuite/literal_py.py.xml
@@ -144,6 +144,26 @@ newlines'</literal></expr></expr_stmt>
 </unit>
 
 <unit revision="1.0.0" language="Python">
+<expr_stmt><expr><literal type="complex">5J</literal></expr></expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="Python">
+<expr_stmt><expr><literal type="complex">0J</literal></expr></expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="Python">
+<expr_stmt><expr><operator>-</operator><literal type="complex">1J</literal></expr></expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="Python">
+<expr_stmt><expr><literal type="complex">5 + 3J</literal></expr></expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="Python">
+<expr_stmt><expr><literal type="number">10</literal> <operator>+</operator> <literal type="complex">5 + 3J</literal></expr></expr_stmt>
+</unit>
+
+<unit revision="1.0.0" language="Python">
 <expr_stmt><expr><literal type="number">0b10101</literal></expr></expr_stmt>
 </unit>
 


### PR DESCRIPTION
Allow code like the following:
```py
5 + 3J
```

to be marked as shown below:
```xml
<expr_stmt><expr><literal type="complex">5 + 3J</literal></expr></expr_stmt>
```