### PR TITLE
Add support for "using" in C++ attributes

### DIFF
--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -7643,10 +7643,29 @@ attribute_cpp[] { CompleteElement element(this); ENTRY_DEBUG } :
         LBRACKET
         LBRACKET
 
+        (attribute_using_cpp)*
         attribute_inner_list
 
         RBRACKET
         RBRACKET
+;
+
+/*
+  attribute_using_cpp
+
+  Handles a "using" keyword in a C++11 attribute.
+*/
+attribute_using_cpp[] { CompleteElement element(this); ENTRY_DEBUG } :
+        {
+            // start a new mode to end after the colon
+            startNewMode(MODE_USING);
+
+            startElement(SUSING_DIRECTIVE);
+        }
+
+        USING
+        compound_name
+        COLON
 ;
 
 attribute_c[] { CompleteElement element(this); ENTRY_DEBUG } :

--- a/test/parser/testsuite/attributes_cpp.cpp.xml
+++ b/test/parser/testsuite/attributes_cpp.cpp.xml
@@ -44,7 +44,6 @@
 <function><attribute>[[<expr><name>System</name></expr>, <expr><name>System</name></expr>]]</attribute> <type><specifier>static</specifier> <name>void</name></type> <name>M</name><parameter_list>(<parameter><decl><type><attribute>[[<expr><name>In</name></expr>, <expr><name>Out</name></expr>]]</attribute> <name>int</name></type> <name>i</name></decl></parameter>)</parameter_list> <block>{<block_content/>}</block></function>
 </unit>
 
-
 <unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C++">
 <decl_stmt><decl><attribute>[[<expr><call><name>System</name><argument_list>()</argument_list></call></expr>]]</attribute> <type><name>int</name></type> <name>i</name></decl>;</decl_stmt>
 </unit>
@@ -107,6 +106,14 @@
 
 <unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C++">
 <decl_stmt><decl><type><name>unsigned</name> <name>int</name></type> <name>a</name> <attribute>[[]]</attribute> <range>: <expr><literal type="number">3</literal></expr></range></decl>;</decl_stmt>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C++">
+<function><attribute>[[<using>using <name>gnu</name>:</using><expr><specifier>const</specifier></expr>, <expr><name>always_inline</name></expr>]]</attribute> <type><name>int</name></type> <name>f</name><parameter_list>()</parameter_list> <block>{<block_content> <return>return <expr><literal type="number">0</literal></expr>;</return> </block_content>}</block></function>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C++">
+<function><attribute>[[<expr><name>noreturn</name></expr>]]</attribute> <type><name>void</name></type> <name>f</name><parameter_list>()</parameter_list> <block>{<block_content> <throw>throw <expr><literal type="string">"error"</literal></expr>;</throw> </block_content>}</block></function>
 </unit>
 
 <unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C++">


### PR DESCRIPTION
Adds parser support to mark up code like the following properly (i.e., `using` in C++ attributes):
```c++
[[using gnu:const, always_inline]] int f() { return 0; }
```