### PR TITLE
Add support for macros in C function tails

### DIFF
--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -5380,6 +5380,10 @@ statement_part[] {
         }?
         macro_call |
 
+        // macro call in function tail
+        { inLanguage(LANGUAGE_C_FAMILY) && inMode(MODE_FUNCTION_TAIL) }?
+        macro_call |
+
         { inMode(MODE_EXPRESSION | MODE_EXPECT) }?
         expression[type, call_count] |
 

--- a/test/parser/testsuite/function_c.c.xml
+++ b/test/parser/testsuite/function_c.c.xml
@@ -52,4 +52,12 @@
 <function><type><name><name>enum</name> <name>foo</name></name></type> <name>bar</name><parameter_list>()</parameter_list> <block>{<block_content> <return>return <expr><literal type="number">0</literal></expr>;</return></block_content>}</block></function>
 </unit>
 
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C">
+<function><type><specifier>static</specifier> <name>void</name> <name>__foo</name> <modifier>*</modifier></type><name>bar</name><parameter_list>(<parameter><decl><type><name>void</name> <modifier>*</modifier></type><name>a</name></decl></parameter>, <parameter><decl><type><name>int</name></type> <name>b</name></decl></parameter>, <parameter><decl><type><name>unsigned</name> <name>long</name> <modifier>*</modifier></type><name>c</name></decl></parameter>)</parameter_list> <macro><name>__baz</name><argument_list>(<argument>&amp;d</argument>)</argument_list></macro> <block>{<block_content/>}</block></function>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C">
+<function><type><name>void</name> <name>__foo</name> <modifier>*</modifier></type><name>bar</name><parameter_list>(<parameter><decl><type><name>void</name> <modifier>*</modifier></type><name>a</name></decl></parameter>, <parameter><decl><type><name>int</name></type> <name>b</name></decl></parameter>, <parameter><decl><type><name>unsigned</name> <name>long</name> <modifier>*</modifier></type><name>c</name></decl></parameter>)</parameter_list> <macro><name>__baz</name><argument_list>(<argument>&amp;d</argument>)</argument_list></macro> <block>{<block_content/>}</block></function>
+</unit>
+
 </unit>


### PR DESCRIPTION
Macros can appear in C function tails. They were not getting marked correctly before, but now they are.

Code:
```c
static void __foo *bar(void *a, int b, unsigned long *c) __baz(&d) {}
```

Proper markup:
```xml
<function><type><specifier>static</specifier> <name>void</name> <name>__foo</name> <modifier>*</modifier></type><name>bar</name><parameter_list>(<parameter><decl><type><name>void</name> <modifier>*</modifier></type><name>a</name></decl></parameter>, <parameter><decl><type><name>int</name></type> <name>b</name></decl></parameter>, <parameter><decl><type><name>unsigned</name> <name>long</name> <modifier>*</modifier></type><name>c</name></decl></parameter>)</parameter_list> <macro><name>__baz</name><argument_list>(<argument>&amp;d</argument>)</argument_list></macro> <block>{<block_content/>}</block></function>
```