### PR TITLE
Fix markup bug with "type" tag not ending properly

### DIFF
--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -11063,6 +11063,14 @@ variable_declaration_type[int type_count] { bool is_compound = false; ENTRY_DEBU
         )*
 
         update_typecount[MODE_VARIABLE_NAME | MODE_INIT]
+
+        {
+            // ensure the type will end in this grammar rule (if not a typedef)
+            if (inTransparentMode(MODE_EAT_TYPE) && !inTransparentMode(MODE_TYPEDEF)) {
+                endDownToMode(MODE_EAT_TYPE);
+                endMode(MODE_EAT_TYPE);
+            }
+        }
 ;
 
 /*

--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -917,7 +917,11 @@ start[] { ++start_count; ENTRY_DEBUG_START ENTRY_DEBUG } :
         offside_dedent |
 
         // characters with special actions that usually end currently open elements
-        { !inTransparentMode(MODE_INTERNAL_END_CURLY) }?
+        // special case for blocks (e.g., lambda capture) in lcurly argument lists
+        {
+            !inTransparentMode(MODE_INTERNAL_END_CURLY)
+            || (inMode(MODE_BLOCK_CONTENT) && inTransparentMode(MODE_ARGUMENT | MODE_LIST))
+        }?
         block_end |
 
         terminate |


### PR DESCRIPTION
This change was intended to fix Issue #2178, but it also handles Issue #2079. The `<type>` tag consumed too many tokens and ended much later than it should have.

**Before**:
```xml
<!-- 2178 -->
<expr_stmt><expr><call><name>Example</name><argument_list>{
    <argument><expr><lambda><capture>[]</capture><parameter_list>()</parameter_list> <block>{<block_content>
        <decl_stmt><decl><type><name>Index</name> <name>index</name> = <name>WITH</name>(<name>Call</name></type></decl>;</decl_stmt><expr_stmt><expr/></expr_stmt></block_content></block></lambda></expr></argument>)</argument_list></call></expr>;</expr_stmt>
    }
}<empty_stmt>;</empty_stmt>

<!-- 2079 -->
<expr_stmt><expr><call><name>foo</name><argument_list>(<argument><expr><lambda><capture>[<argument><modifier>&amp;</modifier></argument>]</capture><parameter_list>()</parameter_list> <block>{<block_content>
        <decl_stmt><decl><type><name>foo</name> <name>rem</name> = <name><name>app</name><operator>.</operator><name>remaining</name></name>(</type></decl>);</decl_stmt>
    </block_content>}</block></lambda></expr></argument>
)</argument_list></call></expr>;</expr_stmt>
```

**After**:
```xml
<!-- 2178 -->
<expr_stmt><expr><call><name>Example</name><argument_list>{
    <argument><expr><lambda><capture>[]</capture><parameter_list>()</parameter_list> <block>{<block_content>
        <decl_stmt><decl><type><name>Index</name></type> <name>index</name> <init>= <macro><name>WITH</name><argument_list>(<argument>Call;</argument>)</argument_list></macro></init></decl>;</decl_stmt>
    </block_content>}</block></lambda></expr></argument>
}</argument_list></call></expr>;</expr_stmt>

<!-- 2079 -->
<expr_stmt><expr><call><name>foo</name><argument_list>(<argument><expr><lambda><capture>[<argument><modifier>&amp;</modifier></argument>]</capture><parameter_list>()</parameter_list> <block>{<block_content>
        <decl_stmt><decl><type><name>foo</name></type> <name>rem</name> <init>= <expr><call><name><name>app</name><operator>.</operator><name>remaining</name></name><argument_list>()</argument_list></call></expr></init></decl>;</decl_stmt>
    </block_content>}</block></lambda></expr></argument>
)</argument_list></call></expr>;</expr_stmt>
```