### PR TITLE
Issue2016

### DIFF
--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -12561,6 +12561,7 @@ derived[] { CompleteElement element(this); ENTRY_DEBUG } :
             identifier |
 
             variable_identifier
+            (options { greedy = true; } : tripledotop)*
         )
 
         (

--- a/test/parser/testsuite/struct_cpp.cpp.xml
+++ b/test/parser/testsuite/struct_cpp.cpp.xml
@@ -55,4 +55,13 @@ struct <name>A</name> <block>{<public type="default">
 <struct_decl>struct <name>a</name>, <name>b</name>, <name>c</name>;</struct_decl>
 </unit>
 
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
+<struct><template>template<parameter_list>&lt;<parameter><type><name>class</name><modifier>...</modifier></type> <name>Args</name></parameter>&gt;</parameter_list></template>
+struct <name>B</name> <super_list>: <super><name>Args</name><modifier>...</modifier></super></super_list> <block>{<public type="default"/>}</block>;</struct>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
+<struct>struct <name>B</name> <super_list>: <super><name>Args</name><modifier>...</modifier></super></super_list> <block>{<public type="default"/>}</block>;</struct>
+</unit>
+
 </unit>


### PR DESCRIPTION
Pack expansion in C++ structs was broken. Originally, the struct was incorrectly marked as a declaration statement.

**Before**:
```xml
<decl_stmt><decl><template>template<parameter_list>&lt;<parameter><type><name>class</name><modifier>...</modifier></type> <name>Args</name></parameter>&gt;</parameter_list></template>
<type><name><name>struct</name> <name>B</name></name></type> <range>: <expr><name>Args</name><operator>...</operator> <block>{}</block></expr></range></decl>;</decl_stmt>
```

**After**:
```xml
<struct><template>template<parameter_list>&lt;<parameter><type><name>class</name><modifier>...</modifier></type> <name>Args</name></parameter>&gt;</parameter_list></template>
struct <name>B</name> <super_list>: <super><name>Args</name><modifier>...</modifier></super></super_list> <block>{<public type="default"/>}</block>;</struct>
```