### PR TITLE
Fix seg. fault with function decl. in Java enums

### DIFF
--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -6802,6 +6802,7 @@ pattern_check_core[
                 || (
                     inLanguage(LANGUAGE_JAVA)
                     && inMode(MODE_ENUM)
+                    && (type_count - specifier_count - attribute_count - template_count == 0)
                     && (
                         fla == COMMA
                         || fla == TERMINATE

--- a/test/parser/testsuite/enum_java.java.xml
+++ b/test/parser/testsuite/enum_java.java.xml
@@ -89,4 +89,14 @@
 }</block></enum>
 </unit>
 
+<unit language="Java">
+<enum><specifier>public</specifier> enum <name>FooEnum</name> <block>{
+    <decl><name>FOO</name></decl>,
+    <decl><name>BAR</name></decl>;
+
+    <function_decl><annotation>@<name>CEnumValue</name></annotation>
+    <type><specifier>private</specifier> <specifier>native</specifier> <name>int</name></type> <name>getBar</name><parameter_list>()</parameter_list>;</function_decl>
+}</block></enum>
+</unit>
+
 </unit>


### PR DESCRIPTION
Before, the following code would cause a segmentation fault:

```java
public enum DarwinSignalEnum {
    @CEnumValue
    private native int getCValue0();
}
```

With this fix, the function declaration is marked properly and no longer crashes srcML:

```xml
<enum><specifier>public</specifier> enum <name>FooEnum</name> <block>{
    <function_decl><annotation>@<name>CEnumValue</name></annotation>
    <type><specifier>private</specifier> <specifier>native</specifier> <name>int</name></type> <name>getBar</name><parameter_list>()</parameter_list>;</function_decl>
}</block></enum>
```