### PR TITLE
Fix markup with comma-separated expr. in indices in C-family

### DIFF
--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -8042,8 +8042,8 @@ complete_expression[] { CompleteElement element(this); ENTRY_DEBUG } :
             // expression with right parentheses if a previous match is in one
             { LA(1) != RPAREN || inTransparentMode(MODE_INTERNAL_END_PAREN) }?
             {
-                // ensure each part of a comma-separated Python index is marked as an expression
-                if (inLanguage(LANGUAGE_PYTHON) && !inMode(MODE_EXPRESSION))
+                // ensure each part of a comma-separated index is marked with an expression tag
+                if (!inMode(MODE_EXPRESSION))
                     startNewMode(MODE_EXPRESSION | MODE_EXPECT);
             }
             expression |

--- a/test/parser/testsuite/operator_c.c.xml
+++ b/test/parser/testsuite/operator_c.c.xml
@@ -34,7 +34,11 @@
 </unit>
 
 <unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C++">
-<expr_stmt><expr><name><name>a</name><index>[<expr><literal type="number">0</literal></expr><operator>,</operator> <literal type="number">0</literal>]</index></name></expr>;</expr_stmt>
+<expr_stmt><expr><name><name>a</name><index>[<expr><literal type="number">0</literal></expr><operator>,</operator> <expr><literal type="number">0</literal></expr>]</index></name></expr>;</expr_stmt>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C++">
+<expr_stmt><expr><name><name>a</name><index>[<expr><literal type="number">0</literal></expr><operator>,</operator> <expr><literal type="string">"1"</literal></expr><operator>,</operator> <expr><literal type="char">'2'</literal></expr><operator>,</operator> <expr><name><name>foo</name><operator>.</operator><name>bar</name></name></expr><operator>,</operator> <expr><literal type="complex">5 + 2i</literal></expr>]</index></name></expr>;</expr_stmt>
 </unit>
 
 <unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C++">

--- a/test/parser/testsuite/operator_cpp.cpp.xml
+++ b/test/parser/testsuite/operator_cpp.cpp.xml
@@ -330,7 +330,11 @@
 </unit>
 
 <unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C++">
-<expr_stmt><expr><name><name>a</name><index>[<expr><literal type="number">0</literal></expr><operator>,</operator> <literal type="number">0</literal>]</index></name></expr>;</expr_stmt>
+<expr_stmt><expr><name><name>a</name><index>[<expr><literal type="number">0</literal></expr><operator>,</operator> <expr><literal type="number">0</literal></expr>]</index></name></expr>;</expr_stmt>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C++">
+<expr_stmt><expr><name><name>a</name><index>[<expr><literal type="number">0</literal></expr><operator>,</operator> <expr><literal type="string">"1"</literal></expr><operator>,</operator> <expr><literal type="char">'2'</literal></expr><operator>,</operator> <expr><name><name>foo</name><operator>.</operator><name>bar</name></name></expr><operator>,</operator> <expr><literal type="boolean">true</literal></expr><operator>,</operator> <expr><literal type="null">nullptr</literal></expr><operator>,</operator> <expr><literal type="complex">5 + 2i</literal></expr>]</index></name></expr>;</expr_stmt>
 </unit>
 
 <unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="C++">

--- a/test/parser/testsuite/operator_m.m.xml
+++ b/test/parser/testsuite/operator_m.m.xml
@@ -22,7 +22,11 @@
 </unit>
 
 <unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="Objective-C">
-<expr_stmt><expr><name><name>a</name><index>[<expr><literal type="number">0</literal></expr><operator>,</operator> <literal type="number">0</literal>]</index></name></expr>;</expr_stmt>
+<expr_stmt><expr><name><name>a</name><index>[<expr><literal type="number">0</literal></expr><operator>,</operator> <expr><literal type="number">0</literal></expr>]</index></name></expr>;</expr_stmt>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="Objective-C">
+<expr_stmt><expr><name><name>a</name><index>[<expr><literal type="number">0</literal></expr><operator>,</operator> <expr><literal type="string">"1"</literal></expr><operator>,</operator> <expr><literal type="char">'2'</literal></expr><operator>,</operator> <expr><name><name>foo</name><operator>.</operator><name>bar</name></name></expr><operator>,</operator> <expr><literal type="complex">5 + 2i</literal></expr>]</index></name></expr>;</expr_stmt>
 </unit>
 
 <unit xmlns:cpp="http://www.srcML.org/srcML/cpp" language="Objective-C">


### PR DESCRIPTION
In C, C++, and Objective-C, the following index (`a[0, 1];`) was marked up incorrectly:
```xml
<expr_stmt><expr><name><name>a</name><index>[<expr><literal type="number">0</literal></expr><operator>,</operator> <literal type="number">1</literal></expr>]</index></name>;</expr_stmt>
```

The new version encloses any expressions after the comma in expression tags:
```xml
<expr_stmt><expr><name><name>a</name><index>[<expr><literal type="number">0</literal></expr><operator>,</operator> <expr><literal type="number">1</literal></expr>]</index></name></expr>;</expr_stmt>
```

This brings some parity to how indices are handled in Python (minus the operator comma):
```xml
<expr_stmt><expr><name><name>a</name><index>[<expr><literal type="number">0</literal></expr>, <expr><literal type="number">1</literal></expr>]</index></name></expr></expr_stmt>
```