### PR TITLE
fix: invalid user-defined conversion to xmlStructuredErrorFunc

### DIFF
--- a/src/client/src_input_file.cpp
+++ b/src/client/src_input_file.cpp
@@ -38,7 +38,7 @@ int src_input_file(ParseQueue& queue,
     std::shared_ptr<ParseRequest> prequest(new ParseRequest);
 
     if (option(SRCML_COMMAND_NOARCHIVE)) {
-        prequest->disk_dir = srcml_request.output_filename;
+        prequest->disk_dir = std::string(srcml_request.output_filename);
     }
 
     if (srcml_request.att_filename)

--- a/src/client/src_input_libarchive.cpp
+++ b/src/client/src_input_libarchive.cpp
@@ -228,7 +228,7 @@ int src_input_libarchive(ParseQueue& queue,
         std::shared_ptr<ParseRequest> prequest(new ParseRequest);
 
         if (option(SRCML_COMMAND_NOARCHIVE))
-            prequest->disk_dir = srcml_request.output_filename;
+            prequest->disk_dir = std::string(srcml_request.output_filename);
 
         if (srcml_request.att_filename || (filename != "-"))
             prequest->filename = filename;

--- a/src/client/src_input_text.cpp
+++ b/src/client/src_input_text.cpp
@@ -67,7 +67,7 @@ int src_input_text(ParseQueue& queue,
         std::shared_ptr<ParseRequest> prequest(new ParseRequest);
 
         if (option(SRCML_COMMAND_NOARCHIVE))
-            prequest->disk_dir = srcml_request.output_filename;
+            prequest->disk_dir = std::string(srcml_request.output_filename);
 
         prequest->filename = srcml_request.att_filename;
         prequest->url = srcml_request.att_url;

--- a/src/libsrcml/sax2_srcsax_handler.cpp
+++ b/src/libsrcml/sax2_srcsax_handler.cpp
@@ -118,7 +118,7 @@ static int reparse_root(void* ctx) {
     memset(&roottagsax, 0, sizeof(roottagsax));
     roottagsax.initialized    = XML_SAX2_MAGIC;
     xmlSetStructuredErrorFunc(ctx, [](void * userData,
-                     xmlErrorPtr /* error */) {
+                     const xmlError* /* error */) {
 
         auto ctxt = (xmlParserCtxtPtr) userData;
         if (ctxt == nullptr)

--- a/src/libsrcml/srcSAXController.cpp
+++ b/src/libsrcml/srcSAXController.cpp
@@ -82,7 +82,7 @@ void srcSAXController::parse(srcSAXHandler * handler) {
 
     if (status != 0) {
 
-        xmlErrorPtr ep = xmlCtxtGetLastError(context->libxml2_context);
+        const xmlError* ep = xmlCtxtGetLastError(context->libxml2_context);
         SAXError error = { std::string(ep->message), ep->code };
 
         throw error;

--- a/src/libsrcml/srcsax_controller.cpp
+++ b/src/libsrcml/srcsax_controller.cpp
@@ -129,7 +129,7 @@ int srcsax_parse(srcsax_context* context) {
 
     if (status != 0 && context->srcsax_error) {
 
-        xmlErrorPtr ep = xmlCtxtGetLastError(context->libxml2_context);
+        const xmlError* ep = xmlCtxtGetLastError(context->libxml2_context);
 
         auto str_length = strlen(ep->message);
         ep->message[str_length - 1] = '\0';


### PR DESCRIPTION
fix #2220
fix #2221

the libxml2 code could be made version-dependent [like](https://github.com/0ad/0ad/commit/d242631245edb66816ef9960bdb2c61b68e56cec.patch)

```c
#if LIBXML_VERSION >= 21200
const xmlError*
#else
xmlErrorPtr
#endif
```
