### PR TITLE
Issue2234

### DIFF
--- a/src/client/src_input_libarchive.cpp
+++ b/src/client/src_input_libarchive.cpp
@@ -16,6 +16,7 @@
 #include <input_curl.hpp>
 #include <SRCMLStatus.hpp>
 #include <libarchive_utilities.hpp>
+#include <unordered_map>
 #include <string_view>
 #include <stdio.h>
 #include <string_view>


### PR DESCRIPTION
Added a missing include file to `src/client/src_input_libarchive.cpp` so the build does not fail:
```c++
#include <unordered_map>
```