### PR TITLE
Add Python <expr_stmt> vs <expr> change.

### DIFF
--- a/src/libsrcml/xpath_generator.cpp
+++ b/src/libsrcml/xpath_generator.cpp
@@ -170,7 +170,8 @@ XPathNode* XPathGenerator::get_xpath_from_argument(std::string src_query) {
     bool change_from_macro = pat_to_srcml.find("macro") != std::string::npos;
     bool extract_expr_from_expr_stmt = language == "Python" &&
                                        pat_to_srcml.find("<",1) == pat_to_srcml.find("<expr_stmt>") &&
-                                       pat_to_srcml.find("<expr_stmt>") == pat_to_srcml.rfind("<expr_stmt>");
+                                       pat_to_srcml.find("<expr_stmt>") == pat_to_srcml.rfind("<expr_stmt>") &&
+                                       pat_to_srcml.find(";</expr_stmt>") == std::string::npos;
 
     if (change_from_macro) {
         srcml_unit* macro_change = srcml_unit_create(holder);

--- a/test/libsrcml/testsuite/test_srcql.cpp
+++ b/test/libsrcml/testsuite/test_srcql.cpp
@@ -2384,6 +2384,54 @@ q, q = q, q # y
         srcml_archive_free(iarchive);
     }
 
+    // FIND $LEFT, $RIGHT = $RIGHT, $LEFT;
+    {
+        char* s;
+        size_t size;
+
+        srcml_archive* oarchive = srcml_archive_create();
+        srcml_archive_write_open_memory(oarchive,&s, &size);
+
+        srcml_unit* unit = srcml_unit_create(oarchive);
+        srcml_unit_set_language(unit,"Python");
+        srcml_unit_parse_memory(unit,python_swap_assignments_src.c_str(),python_swap_assignments_src.size());
+        dassert(srcml_archive_write_unit(oarchive,unit), SRCML_STATUS_OK);
+
+        srcml_unit_free(unit);
+        srcml_archive_close(oarchive);
+        srcml_archive_free(oarchive);
+
+        std::string srcml_text = std::string(s, size);
+        free(s);
+
+        srcml_archive* iarchive = srcml_archive_create();
+        srcml_archive_read_open_memory(iarchive,srcml_text.c_str(),srcml_text.size());
+        dassert(srcml_append_transform_srcql(iarchive,"$LEFT, $RIGHT = $RIGHT, $LEFT;"), SRCML_STATUS_OK);
+
+        unit = srcml_archive_read_unit(iarchive);
+        srcml_transform_result* result = nullptr;
+        srcml_unit_apply_transforms(iarchive, unit, &result);
+
+        dassert(srcml_transform_get_type(result), SRCML_RESULT_UNITS);
+        dassert(srcml_transform_get_unit_size(result), 11);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,0)), python_swap_assignments_expr_stmt_srcml[0]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,1)), python_swap_assignments_expr_stmt_srcml[3]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,2)), python_swap_assignments_expr_stmt_srcml[4]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,3)), python_swap_assignments_expr_stmt_srcml[5]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,4)), python_swap_assignments_expr_stmt_srcml[6]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,5)), python_swap_assignments_expr_stmt_srcml[7]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,6)), python_swap_assignments_expr_stmt_srcml[8]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,7)), python_swap_assignments_expr_stmt_srcml[9]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,8)), python_swap_assignments_expr_stmt_srcml[11]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,9)), python_swap_assignments_expr_stmt_srcml[12]);
+        dassert(srcml_unit_get_srcml_inner(srcml_transform_get_unit(result,10)), python_swap_assignments_expr_stmt_srcml[13]);
+
+        srcml_unit_free(unit);
+        srcml_transform_free(result);
+        srcml_archive_close(iarchive);
+        srcml_archive_free(iarchive);
+    }
+
 
     const std::string call_expressions = R"(
 foo();


### PR DESCRIPTION
This change causes sole expression statements in Python that end with ; to not be converted to just an expression.