### PR TITLE
Adjust Python template parameter markup

### DIFF
--- a/test/parser/testsuite/class_py.py.xml
+++ b/test/parser/testsuite/class_py.py.xml
@@ -84,13 +84,13 @@ class <name>All</name><super_list>(<super><expr><name>Nothing</name></expr></sup
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<class>class <name><name>list</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list></name><block>:<block_content>
+<class>class <name>list</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<class>class <name><name>Box</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list></name><super_list>(<super><expr><name><name>Generic</name><index>[<expr><name>T</name></expr>]</index></name></expr></super>)</super_list><block>:<block_content>
+<class>class <name>Box</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list><super_list>(<super><expr><name><name>Generic</name><index>[<expr><name>T</name></expr>]</index></name></expr></super>)</super_list><block>:<block_content>
     <pass>pass</pass>
 </block_content></block></class>
 </unit>

--- a/test/parser/testsuite/multiline_py.py.xml
+++ b/test/parser/testsuite/multiline_py.py.xml
@@ -900,75 +900,75 @@
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<typedef>type <name><name>ListOrSet</name><parameter_list type="generic">[
+<typedef>type <name>ListOrSet</name><parameter_list type="generic">[
     <parameter><name>T</name></parameter>
-]</parameter_list></name> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>T</name></expr>]</index></name></expr></typedef>
+]</parameter_list> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>T</name></expr>]</index></name></expr></typedef>
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<typedef>type <name><name>ListOrSet</name><parameter_list type="generic">[
+<typedef>type <name>ListOrSet</name><parameter_list type="generic">[
     <comment type="line"># Comment A</comment>
     <parameter><name>T</name></parameter>
     <comment type="hashbang">#! Comment B</comment>
-]</parameter_list></name> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>T</name></expr>]</index></name></expr></typedef>
+]</parameter_list> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>T</name></expr>]</index></name></expr></typedef>
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<typedef>type <name><name>ListOrSet</name><parameter_list type="generic">[
+<typedef>type <name>ListOrSet</name><parameter_list type="generic">[
     <parameter><name>T</name></parameter>,
     <parameter><name>U</name></parameter>
-]</parameter_list></name> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>U</name></expr>]</index></name></expr></typedef>
+]</parameter_list> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>U</name></expr>]</index></name></expr></typedef>
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<typedef>type <name><name>ListOrSet</name><parameter_list type="generic">[
+<typedef>type <name>ListOrSet</name><parameter_list type="generic">[
     <comment type="line"># Comment A</comment>
     <parameter><name>T</name></parameter>,
     <comment type="hashbang">#! Comment B</comment>
     <parameter><name>U</name></parameter>
     <comment type="line"># Comment C</comment>
-]</parameter_list></name> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>U</name></expr>]</index></name></expr></typedef>
+]</parameter_list> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>U</name></expr>]</index></name></expr></typedef>
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<function>def <name><name>max</name><parameter_list type="generic">[
+<function>def <name>max</name><parameter_list type="generic">[
     <parameter><name>T</name></parameter>,
     <parameter><name>U</name></parameter>
-]</parameter_list></name><parameter_list>(<parameter><name>args</name><annotation>: <expr><name><name>Iterable</name><index>[<expr><name>T</name></expr>]</index></name></expr></annotation></parameter>)</parameter_list> <annotation>-&gt; <expr><name>T</name></expr></annotation><block>:<block_content>
+]</parameter_list><parameter_list>(<parameter><name>args</name><annotation>: <expr><name><name>Iterable</name><index>[<expr><name>T</name></expr>]</index></name></expr></annotation></parameter>)</parameter_list> <annotation>-&gt; <expr><name>T</name></expr></annotation><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"srcML"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<function>def <name><name>max</name><parameter_list type="generic">[
+<function>def <name>max</name><parameter_list type="generic">[
     <comment type="line"># Comment A</comment>
     <parameter><name>T</name></parameter>,
     <comment type="hashbang">#! Comment B</comment>
     <parameter><name>U</name></parameter>
     <comment type="line"># Comment C</comment>
-]</parameter_list></name><parameter_list>(<parameter><name>args</name><annotation>: <expr><name><name>Iterable</name><index>[<expr><name>T</name></expr>]</index></name></expr></annotation></parameter>)</parameter_list> <annotation>-&gt; <expr><name>T</name></expr></annotation><block>:<block_content>
+]</parameter_list><parameter_list>(<parameter><name>args</name><annotation>: <expr><name><name>Iterable</name><index>[<expr><name>T</name></expr>]</index></name></expr></annotation></parameter>)</parameter_list> <annotation>-&gt; <expr><name>T</name></expr></annotation><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"srcML"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<class>class <name><name>list</name><parameter_list type="generic">[
+<class>class <name>list</name><parameter_list type="generic">[
     <parameter><name>T</name></parameter>,
     <parameter><name>U</name></parameter>
-]</parameter_list></name><block>:<block_content>
+]</parameter_list><block>:<block_content>
     <function>def <name>sample</name><parameter_list>(<parameter><name>self</name></parameter>, <parameter><name>element</name><annotation>: <expr><name>T</name></expr></annotation></parameter>)</parameter_list> <annotation>-&gt; <expr><name>T</name></expr></annotation><block>:<block_content>
         <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"srcML"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function></block_content></block></class>
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<class>class <name><name>list</name><parameter_list type="generic">[
+<class>class <name>list</name><parameter_list type="generic">[
     <comment type="line"># Comment A</comment>
     <parameter><name>T</name></parameter>,
     <comment type="hashbang">#! Comment B</comment>
     <parameter><name>U</name></parameter>
     <comment type="line"># Comment C</comment>
-]</parameter_list></name><block>:<block_content>
+]</parameter_list><block>:<block_content>
     <function>def <name>sample</name><parameter_list>(<parameter><name>self</name></parameter>, <parameter><name>element</name><annotation>: <expr><name>T</name></expr></annotation></parameter>)</parameter_list> <annotation>-&gt; <expr><name>T</name></expr></annotation><block>:<block_content>
         <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"srcML"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function></block_content></block></class>
@@ -998,10 +998,10 @@
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<class>class <name><name>Box</name><parameter_list type="generic">[
+<class>class <name>Box</name><parameter_list type="generic">[
     <parameter><name>T</name></parameter>,
     <parameter><name>U</name></parameter>
-]</parameter_list></name><super_list>(
+]</parameter_list><super_list>(
     <super><expr><name><name>Generic</name><index>[<expr><name>T</name></expr>]</index></name></expr></super>,
     <super><expr><name><name>Generic</name><index>[<expr><name>U</name></expr>]</index></name></expr></super>
 )</super_list><block>:<block_content>
@@ -1011,13 +1011,13 @@
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<class>class <name><name>Box</name><parameter_list type="generic">[
+<class>class <name>Box</name><parameter_list type="generic">[
     <comment type="line"># Comment A</comment>
     <parameter><name>T</name></parameter>,
     <comment type="hashbang">#! Comment B</comment>
     <parameter><name>U</name></parameter>
     <comment type="line"># Comment C</comment>
-]</parameter_list></name><super_list>(
+]</parameter_list><super_list>(
     <comment type="hashbang">#! Comment D</comment>
     <super><expr><name><name>Generic</name><index>[<expr><name>T</name></expr>]</index></name></expr></super>,
     <comment type="line"># Comment E</comment>

--- a/test/parser/testsuite/parameter_py.py.xml
+++ b/test/parser/testsuite/parameter_py.py.xml
@@ -139,7 +139,7 @@
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<function>def <name><name>max</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list></name><parameter_list>(<parameter><name>args</name><annotation>: <expr><name><name>Iterable</name><index>[<expr><name>T</name></expr>]</index></name></expr></annotation></parameter>)</parameter_list> <annotation>-&gt; <expr><name>T</name></expr></annotation><block>:<block_content>
+<function>def <name>max</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list><parameter_list>(<parameter><name>args</name><annotation>: <expr><name><name>Iterable</name><index>[<expr><name>T</name></expr>]</index></name></expr></annotation></parameter>)</parameter_list> <annotation>-&gt; <expr><name>T</name></expr></annotation><block>:<block_content>
     <expr_stmt><expr><call><name>print</name><argument_list>(<argument><expr><literal type="string">"srcML"</literal></expr></argument>)</argument_list></call></expr></expr_stmt>
 </block_content></block></function>
 </unit>
@@ -165,7 +165,7 @@
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<function>def <name><name>example</name><parameter_list type="generic">[<parameter><name>T</name></parameter>, <parameter><name>U</name></parameter>, <parameter><name>V</name></parameter>,]</parameter_list></name><parameter_list>(
+<function>def <name>example</name><parameter_list type="generic">[<parameter><name>T</name></parameter>, <parameter><name>U</name></parameter>, <parameter><name>V</name></parameter>,]</parameter_list><parameter_list>(
     <parameter><name>a</name></parameter>,
     <parameter><name>b</name></parameter>,
     <parameter><name>c</name></parameter>,

--- a/test/parser/testsuite/typedef_py.py.xml
+++ b/test/parser/testsuite/typedef_py.py.xml
@@ -14,7 +14,7 @@
 </unit>
 
 <unit revision="1.0.0" language="Python">
-<typedef>type <name><name>ListOrSet</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list></name> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>T</name></expr>]</index></name></expr></typedef>
+<typedef>type <name>ListOrSet</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list> = <expr><name><name>list</name><index>[<expr><name>T</name></expr>]</index></name> <operator>|</operator> <name><name>set</name><index>[<expr><name>T</name></expr>]</index></name></expr></typedef>
 </unit>
 
 </unit>


### PR DESCRIPTION
In Python, template parameter lists were marked up incorrectly. They used to follow the naming convention for indices, where they would be nested in a compound name. This is incorrect.

Code:
```py
def func[T]():
    pass


class CLS[T]:
    pass


type ListOrSet[T] = X
```

Corrected markup:
```xml
<function>def <name>func</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list><parameter_list>()</parameter_list><block>:<block_content>
    <pass>pass</pass>
</block_content></block></function>

<class>class <name>CLS</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list><block>:<block_content>
    <pass>pass</pass>
</block_content></block></class>

<typedef>type <name>ListOrSet</name><parameter_list type="generic">[<parameter><name>T</name></parameter>]</parameter_list> = <expr><name>X</name></expr></typedef>
```