### PR TITLE
Add default explicit copy constructors and assignment operators

### DIFF
--- a/src/libsrcml/language_extension_registry.hpp
+++ b/src/libsrcml/language_extension_registry.hpp
@@ -42,6 +42,9 @@ public:
     language_extension_registry();
     ~language_extension_registry();
 
+    language_extension_registry(const language_extension_registry&) = default;
+    language_extension_registry& operator=(const language_extension_registry&) = default;
+
     bool register_user_ext(const char* ext, int language);
     bool register_user_ext(const char* ext, const char* language);
 

--- a/src/parser/srcMLState.hpp
+++ b/src/parser/srcMLState.hpp
@@ -40,6 +40,12 @@ public:
         : flags(mode), flags_prev(prevmode), flags_all(transmode | mode), parencount(0), curlycount(0), typecount(0)
     {}
 
+    // copy constructor
+    srcMLState(const srcMLState&) = default;
+
+    // copy assignment
+    srcMLState& operator=(const srcMLState&) = default;
+
     /**
      * size
      *


### PR DESCRIPTION
Fix #2261 