### PR TITLE
Issue2260

### DIFF
--- a/src/client/src_input_libarchive.cpp
+++ b/src/client/src_input_libarchive.cpp
@@ -413,7 +413,7 @@ schedule:
 
             // process a YAML header
             auto& buffer = prequest->buffer;
-            if (buffer.size() > 7 && buffer[0] == '-' && buffer[1] == '-' && buffer[2] == '-') {
+            if (buffer.size() > 7 && buffer[0] == '-' && buffer[1] == '-' && buffer[2] == '-' && buffer[3] == '\n') {
 
                 auto endpos = std::search(buffer.begin() + 3, buffer.end(), "---"sv.begin(), "---"sv.end());
                 if (endpos != buffer.end()) {

--- a/test/client/testsuite/header_archive.sh
+++ b/test/client/testsuite/header_archive.sh
@@ -319,3 +319,48 @@ check projectRootOutput.xml
 
 cat projectRoot.txt | srcml
 check projectRootOutput.xml
+
+defineXML notHeaderOutputXML <<- 'STDOUT'
+	<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+STDOUT
+createfile notHeaderOutput.xml "$notHeaderOutputXML"
+
+define file1NotHeader <<-'EOF'
+	-----BEGIN PRIVATE KEY-----
+	ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/+=
+	-----END PRIVATE KEY-----
+	-----BEGIN CERTIFICATE-----
+	ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/+=
+	-----END CERTIFICATE-----
+EOF
+
+define file2NotHeader <<-'EOF'
+	------------------------------------------------------------------------
+	-- example.decTest -- example                                         --
+	-- Copyright (c) ...                                                  --
+	------------------------------------------------------------------------
+	-- Example1                                                           --
+	--                                                                    --
+	-- "Example2"                                                         --
+	--                                                                    --
+	-- 'Example3'                                                         --
+	------------------------------------------------------------------------
+	version: XX.YY.ZZ
+
+	-- Example4
+
+	a: 0
+	b: example_five
+	c: 10
+	d: -10
+
+	'1' -> '1'
+EOF
+
+echo -n "$file1NotHeader" > file1NotHeader.pem
+srcml file1NotHeader.pem -o file1NotHeader.pem.xml
+diff notHeaderOutput.xml file1NotHeader.pem.xml
+
+echo -n "$file2NotHeader" > file2NotHeader.decTest
+srcml file2NotHeader.decTest -o file2NotHeader.decTest.xml
+diff notHeaderOutput.xml file2NotHeader.decTest.xml


### PR DESCRIPTION
Certain unsupported files caused srcML to enter an infinite loop or crash. These changes should fix that. I also added the following test cases to the srcML client test suite:

`.pem` file:
```
-----BEGIN PRIVATE KEY-----
ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/+=
-----END PRIVATE KEY-----
-----BEGIN CERTIFICATE-----
ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/+=
-----END CERTIFICATE-----
```

`.decTest` file:
```
------------------------------------------------------------------------
-- example.decTest -- example                                         --
-- Copyright (c) ...                                                  --
------------------------------------------------------------------------
-- Example1                                                           --
--                                                                    --
-- "Example2"                                                         --
--                                                                    --
-- 'Example3'                                                         --
------------------------------------------------------------------------
version: XX.YY.ZZ

-- Example4

a: 0
b: example_five
c: 10
d: -10

'1' -> '1'
```