### PR TITLE
Fix bug with line continuation next to start of a Python block

### DIFF
--- a/src/parser/OffSideRule.cpp
+++ b/src/parser/OffSideRule.cpp
@@ -61,8 +61,30 @@ antlr::RefToken OffSideRule::nextToken() {
  * Operates under the assumption `token` is an INDENT token.
  */
 void OffSideRule::handleBlocks(antlr::RefToken token) {
+    int numTokensAfterIndent = 0;  // restricted to 0-2 (inclusive)
+    bool stopCounting = false;
+
     while (true) {
         const auto& nextToken = input.nextToken();  // reads in a token
+
+        // incrementing to detect the first and second token after the INDENT
+        if (!stopCounting)
+            ++numTokensAfterIndent;
+
+        // the backslash does NOT indicate a one-line statement
+        if (numTokensAfterIndent < 3 && nextToken->getType() == srcMLParser::EOL_BACKSLASH) {
+            indentBuffer.emplace_back(nextToken);
+            isOneLineStatement = false;
+            checkOneLineStatement = false;
+            stopCounting = true;  // do not need to count after the second token
+
+            continue;
+        }
+
+        // do not need to count after the second token
+        if (!stopCounting && numTokensAfterIndent > 2)
+            stopCounting = true;
+
         int startingIndents = numIndents;
         bool addNextToken = true;  // Ensure nextToken was not already added to the indent buffer
 

--- a/test/parser/testsuite/multiline_py.py.xml
+++ b/test/parser/testsuite/multiline_py.py.xml
@@ -1135,4 +1135,19 @@ ligula a lectus maximus mollis."</literal></expr></expr_stmt>
 </block_content></block></function>
 </unit>
 
+<unit revision="1.0.0" language="Python">
+<function>def <name>a</name><parameter_list>()</parameter_list><block>:<block_content> \
+    <comment type="line"># b</comment>
+    <pass>pass</pass>
+</block_content></block></function>
+</unit>
+
+<unit revision="1.0.0" language="Python">
+<function>def <name>a</name><parameter_list>()</parameter_list><block>:<block_content> \
+    \
+  <comment type="line"># b</comment>
+    <pass>pass</pass>
+</block_content></block></function>
+</unit>
+
 </unit>


### PR DESCRIPTION
The following no longer causes a segmentation fault:
```py
def a(): \
    # b
    pass
```

This was a problem in `OffSideRule`; I didn't have logic that handled a line continuation character immediately after a block begins.