### PR TITLE
v1.1.0 beta

### DIFF
--- a/.github/actions/test-client/action.yml
+++ b/.github/actions/test-client/action.yml
@@ -1,0 +1,35 @@
+name: 'Test srcML Client'
+description: 'Run srcML client tests and upload test logs'
+inputs:
+  prefix:
+    description: 'Prefix for artifact names'
+    required: true
+  working-directory:
+    description: 'Working directory for tests'
+    required: false
+    default: 'build'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Test client
+      working-directory: ${{ inputs.working-directory }}
+      continue-on-error: true
+      shell: bash
+      run: |
+        cmake --build . --target test_client
+    
+    - name: Upload LastTest.log
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      if: ${{ hashFiles('Testing/Temporary/LastTest.log') != '' }}
+      with:
+        name: ${{ inputs.prefix }}-client_last_test.log
+        path: ${{ inputs.working-directory }}/Testing/Temporary/LastTest.log
+    
+    - name: Upload client logs
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: ${{ inputs.prefix }}-client.log
+        path: ${{ inputs.working-directory }}/dist/*-client.log

--- a/.github/actions/test-client/action.yml
+++ b/.github/actions/test-client/action.yml
@@ -31,5 +31,5 @@ runs:
       uses: actions/upload-artifact@v4
       continue-on-error: true
       with:
-        name: ${{ inputs.prefix }}-client.log
+        name: "${{ inputs.prefix }} Client Test Log"
         path: ${{ inputs.working-directory }}/dist/*-client.log

--- a/.github/actions/test-libsrcml/action.yml
+++ b/.github/actions/test-libsrcml/action.yml
@@ -1,0 +1,34 @@
+name: 'Test srcML libsrcml'
+description: 'Run srcML libsrcml tests and upload test logs'
+inputs:
+  prefix:
+    description: 'Prefix for artifact names'
+    required: true
+  working-directory:
+    description: 'Working directory for tests'
+    required: false
+    default: 'build'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Test libsrcml
+      working-directory: ${{ inputs.working-directory }}
+      continue-on-error: true
+      shell: bash
+      run: |
+        cmake --build . --target test_libsrcml
+    
+    - name: Upload LastTest.log
+      uses: actions/upload-artifact@v4
+      if: ${{ hashFiles('Testing/Temporary/LastTest.log') != '' }}
+      with:
+        name: ${{ inputs.prefix }}-libsrcml_last_test.log
+        path: ${{ inputs.working-directory }}/Testing/Temporary/LastTest.log
+    
+    - name: Upload libsrcml logs
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: ${{ inputs.prefix }}-libsrcml.log
+        path: ${{ inputs.working-directory }}/dist/*-libsrcml.log

--- a/.github/actions/test-libsrcml/action.yml
+++ b/.github/actions/test-libsrcml/action.yml
@@ -21,6 +21,7 @@ runs:
     
     - name: Upload LastTest.log
       uses: actions/upload-artifact@v4
+      continue-on-error: true
       if: ${{ hashFiles('Testing/Temporary/LastTest.log') != '' }}
       with:
         name: ${{ inputs.prefix }}-libsrcml_last_test.log
@@ -30,5 +31,5 @@ runs:
       uses: actions/upload-artifact@v4
       continue-on-error: true
       with:
-        name: ${{ inputs.prefix }}-libsrcml.log
+        name: "${{ inputs.prefix }} Libsrcml Test Log"
         path: ${{ inputs.working-directory }}/dist/*-libsrcml.log

--- a/.github/actions/test-parser/action.yml
+++ b/.github/actions/test-parser/action.yml
@@ -23,5 +23,5 @@ runs:
       uses: actions/upload-artifact@v4
       continue-on-error: true
       with:
-        name: ${{ inputs.prefix }}-parser.log
+        name: "${{ inputs.prefix }} Parser Test Log"
         path: ${{ inputs.working-directory }}/dist/*-parser.log

--- a/.github/actions/test-parser/action.yml
+++ b/.github/actions/test-parser/action.yml
@@ -1,0 +1,27 @@
+name: 'Test srcML Parser'
+description: 'Run srcML parser tests and upload test logs'
+inputs:
+  prefix:
+    description: 'Prefix for artifact names'
+    required: true
+  working-directory:
+    description: 'Working directory for tests'
+    required: false
+    default: 'build'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Test parser
+      working-directory: ${{ inputs.working-directory }}
+      continue-on-error: true
+      shell: bash
+      run: |
+        cmake --build . --target test_parser
+    
+    - name: Upload parser test log
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: ${{ inputs.prefix }}-parser.log
+        path: ${{ inputs.working-directory }}/dist/*-parser.log

--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -41,7 +41,7 @@ runs:
         key: vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
         restore-keys: |
           vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-
-          vcpkg-bin-v1-Windows-x64-windows-e140b1fde236eb682b0d47f905e65008a191800f-
+          vcpkg-bin-v1-Windows-x64-windows-e140b1fde236eb682b0d47f905e65008a191800f-1ef434285e3631aa465128c90367d72ee2f5d8dd9ff7cc12998ab449a23eef74
           vcpkg-bin-v1-${{ runner.os }}-
 
     # - name: Cache vcpkg downloads (optional)

--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -24,6 +24,7 @@ runs:
         echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
         echo "VCPKG_DEFAULT_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
         echo "VCPKG_DEFAULT_HOST_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
+        echo "VCPKG_BUILD_TYPE=release" >> "$GITHUB_ENV"
         mkdir -p "$GITHUB_WORKSPACE/vcpkg-cache"
 
     - name: Cache vcpkg binary artifacts

--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -1,7 +1,7 @@
 name: Setup vcpkg with cache
 
 description: |
-  Checks out vcpkg, bootstraps it, and sets up binary cache.
+  Checks out vcpkg, bootstraps it, and sets up binary cache for Release builds only.
 
 inputs:
   vcpkg-ref:
@@ -22,24 +22,18 @@ runs:
         echo "VCPKG_FEATURE_FLAGS=manifests,binarycaching" >> "$GITHUB_ENV"
         echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg-cache" >> "$GITHUB_ENV"
         echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
+        echo "VCPKG_DEFAULT_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
+        echo "VCPKG_DEFAULT_HOST_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
         mkdir -p "$GITHUB_WORKSPACE/vcpkg-cache"
 
     - name: Cache vcpkg binary artifacts
       uses: actions/cache@v4
       with:
         path: ${{ env.VCPKG_CACHE_DIR }}
-        key: vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
+        key: vcpkg-bin-release-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
         restore-keys: |
-          vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-
-          vcpkg-bin-v1-${{ runner.os }}-
-
-    # - name: Cache vcpkg downloads (optional)
-    #   uses: actions/cache@v4
-    #   with:
-    #     path: C:\Users\runneradmin\AppData\Local\vcpkg\downloads
-    #     key: vcpkg-dl-v1-${{ runner.os }}-${{ inputs.vcpkg-ref }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
-    #     restore-keys: |
-    #       vcpkg-dl-v1-${{ runner.os }}-
+          vcpkg-bin-release-v1-${{ runner.os }}-${{ inputs.triplet }}-
+          vcpkg-bin-release-v1-${{ runner.os }}-
 
     - name: Clone vcpkg
       shell: bash

--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -24,16 +24,6 @@ runs:
         echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
         mkdir -p "$GITHUB_WORKSPACE/vcpkg-cache"
 
-    # - name: Cache vcpkg binary artifacts
-    #   uses: actions/cache@v4
-    #   with:
-    #     path: ${{ env.VCPKG_CACHE_DIR }}
-    #     key: vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ inputs.vcpkg-ref }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
-    #     restore-keys: |
-    #       vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ inputs.vcpkg-ref }}-
-    #       vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-
-    #       vcpkg-bin-v1-${{ runner.os }}-
-
     - name: Cache vcpkg binary artifacts
       uses: actions/cache@v4
       with:
@@ -41,7 +31,6 @@ runs:
         key: vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
         restore-keys: |
           vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-
-          vcpkg-bin-v1-Windows-x64-windows-e140b1fde236eb682b0d47f905e65008a191800f-1ef434285e3631aa465128c90367d72ee2f5d8dd9ff7cc12998ab449a23eef74
           vcpkg-bin-v1-${{ runner.os }}-
 
     # - name: Cache vcpkg downloads (optional)

--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -24,14 +24,25 @@ runs:
         echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
         mkdir -p "$GITHUB_WORKSPACE/vcpkg-cache"
 
+    # - name: Cache vcpkg binary artifacts
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: ${{ env.VCPKG_CACHE_DIR }}
+    #     key: vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ inputs.vcpkg-ref }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
+    #     restore-keys: |
+    #       vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ inputs.vcpkg-ref }}-
+    #       vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-
+    #       vcpkg-bin-v1-${{ runner.os }}-
+
     - name: Cache vcpkg binary artifacts
       uses: actions/cache@v4
       with:
         path: ${{ env.VCPKG_CACHE_DIR }}
-        key: vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ inputs.vcpkg-ref }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
+        key: vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
         restore-keys: |
-          vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ inputs.vcpkg-ref }}-
           vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-
+          # Legacy scheme (per-branch/per-ref)
+          vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ inputs.vcpkg-ref }}-
           vcpkg-bin-v1-${{ runner.os }}-
 
     # - name: Cache vcpkg downloads (optional)

--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -1,7 +1,7 @@
 name: Setup vcpkg with cache
 
 description: |
-  Checks out vcpkg, bootstraps it, and sets up binary cache for Release builds only.
+  Checks out vcpkg, bootstraps it, and sets up binary cache with optional R2 remote cache.
 
 inputs:
   vcpkg-ref:
@@ -12,6 +12,22 @@ inputs:
     description: 'vcpkg triplet (used only for cache partitioning)'
     required: false
     default: 'x64-windows'
+  r2-access-key:
+    description: 'Cloudflare R2 access key (optional - enables remote cache)'
+    required: false
+    default: ''
+  r2-secret-key:
+    description: 'Cloudflare R2 secret key (optional - enables remote cache)'
+    required: false
+    default: ''
+  r2-bucket:
+    description: 'R2 bucket name for vcpkg cache (optional)'
+    required: false
+    default: ''
+  r2-endpoint:
+    description: 'R2 endpoint URL (optional)'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -21,11 +37,19 @@ runs:
       run: |
         echo "VCPKG_FEATURE_FLAGS=manifests,binarycaching" >> "$GITHUB_ENV"
         echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg-cache" >> "$GITHUB_ENV"
-        echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
         echo "VCPKG_DEFAULT_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
         echo "VCPKG_DEFAULT_HOST_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
         echo "VCPKG_BUILD_TYPE=release" >> "$GITHUB_ENV"
         mkdir -p "$GITHUB_WORKSPACE/vcpkg-cache"
+
+        # Configure binary sources based on whether R2 credentials are provided
+        if [ -n "${{ inputs.r2-access-key }}" ] && [ -n "${{ inputs.r2-secret-key }}" ]; then
+          echo "Setting up R2 remote cache + local fallback"
+          echo "VCPKG_BINARY_SOURCES=clear;s3,${{ inputs.r2-endpoint }},${{ inputs.r2-bucket }}/vcpkg-cache,readwrite,,,${{ inputs.r2-access-key }},${{ inputs.r2-secret-key }};files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
+        else
+          echo "Using local cache only"
+          echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
+        fi
 
     - name: Cache vcpkg binary artifacts
       uses: actions/cache@v4

--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -8,21 +8,39 @@ inputs:
     description: 'Git ref for vcpkg (commit, tag, or branch)'
     required: false
     default: 'e140b1fde236eb682b0d47f905e65008a191800f'
+  triplet:
+    description: 'vcpkg triplet (used only for cache partitioning)'
+    required: false
+    default: 'x64-windows'
 
 runs:
   using: "composite"
   steps:
+    - name: Set vcpkg cache env
+      shell: bash
+      run: |
+        echo "VCPKG_FEATURE_FLAGS=manifests,binarycaching" >> "$GITHUB_ENV"
+        echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg-cache" >> "$GITHUB_ENV"
+        echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
+        mkdir -p "$GITHUB_WORKSPACE/vcpkg-cache"
+
     - name: Cache vcpkg binary artifacts
       uses: actions/cache@v4
       with:
-        path: ${{ github.workspace }}/vcpkg-cache
-        key: vcpkg-cache-${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
+        path: ${{ env.VCPKG_CACHE_DIR }}
+        key: vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ inputs.vcpkg-ref }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
         restore-keys: |
-          vcpkg-cache-${{ runner.os }}-
+          vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ inputs.vcpkg-ref }}-
+          vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-
+          vcpkg-bin-v1-${{ runner.os }}-
 
-    - name: Set vcpkg binary source env
-      shell: bash
-      run: echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> $GITHUB_ENV
+    # - name: Cache vcpkg downloads (optional)
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: C:\Users\runneradmin\AppData\Local\vcpkg\downloads
+    #     key: vcpkg-dl-v1-${{ runner.os }}-${{ inputs.vcpkg-ref }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
+    #     restore-keys: |
+    #       vcpkg-dl-v1-${{ runner.os }}-
 
     - name: Clone vcpkg
       shell: bash

--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -55,6 +55,13 @@ runs:
           echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
         fi
 
+    - name: Debug vcpkg env
+      shell: bash
+      run: |
+        echo "VCPKG_BINARY_SOURCES=$VCPKG_BINARY_SOURCES"
+        echo "AWS_ENDPOINT_URL=$AWS_ENDPOINT_URL"
+        echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
+
     - name: Cache vcpkg binary artifacts
       uses: actions/cache@v4
       with:

--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -41,8 +41,7 @@ runs:
         key: vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
         restore-keys: |
           vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-
-          # Legacy scheme (per-branch/per-ref)
-          vcpkg-bin-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ inputs.vcpkg-ref }}-
+          vcpkg-bin-v1-Windows-x64-windows-e140b1fde236eb682b0d47f905e65008a191800f-
           vcpkg-bin-v1-${{ runner.os }}-
 
     # - name: Cache vcpkg downloads (optional)

--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -45,7 +45,11 @@ runs:
         # Configure binary sources based on whether R2 credentials are provided
         if [ -n "${{ inputs.r2-access-key }}" ] && [ -n "${{ inputs.r2-secret-key }}" ]; then
           echo "Setting up R2 remote cache + local fallback"
-          echo "VCPKG_BINARY_SOURCES=clear;s3,${{ inputs.r2-endpoint }},${{ inputs.r2-bucket }}/vcpkg-cache,readwrite,,,${{ inputs.r2-access-key }},${{ inputs.r2-secret-key }};files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
+          echo "VCPKG_BINARY_SOURCES=clear;x-aws,${{ inputs.r2-bucket }}/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
+          echo "AWS_ACCESS_KEY_ID=${{ inputs.r2-access-key }}" >> "$GITHUB_ENV"
+          echo "AWS_SECRET_ACCESS_KEY=${{ inputs.r2-secret-key }}" >> "$GITHUB_ENV"
+          echo "AWS_DEFAULT_REGION=auto" >> "$GITHUB_ENV"
+          echo "AWS_ENDPOINT_URL=${{ inputs.r2-endpoint }}" >> "$GITHUB_ENV"
         else
           echo "Using local cache only"
           echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"

--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -45,7 +45,7 @@ runs:
         # Configure binary sources based on whether R2 credentials are provided
         if [ -n "${{ inputs.r2-access-key }}" ] && [ -n "${{ inputs.r2-secret-key }}" ]; then
           echo "Setting up R2 remote cache + local fallback"
-          echo "VCPKG_BINARY_SOURCES=clear;x-aws,${{ inputs.r2-bucket }}/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
+          echo "VCPKG_BINARY_SOURCES=clear;x-aws,s3://${{ inputs.r2-bucket }}/vcpkg-cache,readwrite;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
           echo "AWS_ACCESS_KEY_ID=${{ inputs.r2-access-key }}" >> "$GITHUB_ENV"
           echo "AWS_SECRET_ACCESS_KEY=${{ inputs.r2-secret-key }}" >> "$GITHUB_ENV"
           echo "AWS_DEFAULT_REGION=auto" >> "$GITHUB_ENV"

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-15]
-        architecture: [arm64] #[Universal, x86_64, arm64]
+        architecture: [Universal, x86_64, arm64]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Test parser
         uses: ./.github/actions/test-parser
         with:
-          prefix: ${{ matrix.architecture }}.${{ matrix.os }}
+          prefix: ${{ matrix.os }}.${{ matrix.architecture }}
 
       - name: Upload installer
         uses: actions/upload-artifact@v4

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -69,6 +69,15 @@ jobs:
         run: |
           ninja run_parser_tests
 
+      - name: Upload installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: macOS Universal Package
+          path: |
+            /Users/runner/work/srcML/srcML-build/dist/*.pkg
+            /Users/runner/work/srcML/srcML-build/dist/*.tar.gz
+            /Users/runner/work/srcML/srcML-build/dist/*.tar.bz2
+
       - name: Clean
         shell: bash
         run: |
@@ -85,6 +94,15 @@ jobs:
         shell: bash
         run: |
           cpack
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: macOS x86_64 Package
+          path: |
+            /Users/runner/work/srcML/srcML-build/dist/*.pkg
+            /Users/runner/work/srcML/srcML-build/dist/*.tar.gz
+            /Users/runner/work/srcML/srcML-build/dist/*.tar.bz2
 
       - name: Clean
         shell: bash
@@ -106,7 +124,7 @@ jobs:
       - name: Upload installer
         uses: actions/upload-artifact@v4
         with:
-          name: installers
+          name: macOS arm64 Package
           path: |
             /Users/runner/work/srcML/srcML-build/dist/*.pkg
             /Users/runner/work/srcML/srcML-build/dist/*.tar.gz

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -43,6 +43,7 @@ jobs:
           cpack
 
       - name: Install package
+        working-directory: build/dist
         shell: bash
         run: |
           sudo installer -dumplog -pkg srcml-*-macOS*.pkg -target /

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          cmake --build --preset ci-macos
+          cmake -B build --build --preset ci-macos
 
       - name: Package
         working-directory: build

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -57,17 +57,17 @@ jobs:
       - name: Test client
         uses: ./.github/actions/test-client
         with:
-          prefix: ${{ matrix.os }}.${{ matrix.architecture }}
+          prefix: "macOS ${{ matrix.architecture }}"
 
       - name: Test libsrcml
         uses: ./.github/actions/test-libsrcml
         with:
-          prefix: ${{ matrix.os }}.${{ matrix.architecture }}
+          prefix: "macOS ${{ matrix.architecture }}"
 
       - name: Test parser
         uses: ./.github/actions/test-parser
         with:
-          prefix: ${{ matrix.os }}.${{ matrix.architecture }}
+          prefix: "macOS ${{ matrix.architecture }}"
 
       - name: Upload installer
         uses: actions/upload-artifact@v4

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-15]
-        architecture: [Universal, x86_64, arm64]
+        architecture: [arm64] #[Universal, x86_64, arm64]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -72,7 +72,8 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          cmake --build --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=x86_64
+          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=x86_64 -U CMAKE_OSX_ARCHITECTURES
+          cmake --build --preset ci-macos
 
       - name: Package
         working-directory: ../srcML-build
@@ -83,7 +84,8 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          cmake --build --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=arm64
+          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=arm64 -U CMAKE_OSX_ARCHITECTURES
+          cmake --build --preset ci-macos
 
       - name: Package
         working-directory: ../srcML-build

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -69,6 +69,28 @@ jobs:
         run: |
           ninja run_parser_tests
 
+      - name: Build
+        shell: bash
+        run: |
+          cmake --build --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=x86_64
+
+      - name: Package
+        working-directory: ../srcML-build
+        shell: bash
+        run: |
+          cpack
+
+      - name: Build
+        shell: bash
+        run: |
+          cmake --build --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=arm64
+
+      - name: Package
+        working-directory: ../srcML-build
+        shell: bash
+        run: |
+          cpack
+
       - name: Upload installer
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -57,19 +57,19 @@ jobs:
       - name: Test client
         uses: ./.github/actions/test-client
         with:
-          working-directory: ~/srcML-build
+          working-directory: ../srcML-build
           prefix: ${{ matrix.os }}.${{ matrix.architecture }}
 
       - name: Test libsrcml
         uses: ./.github/actions/test-libsrcml
         with:
-          working-directory: ~/srcML-build
+          working-directory: ../srcML-build
           prefix: ${{ matrix.os }}.${{ matrix.architecture }}
 
       - name: Test parser
         uses: ./.github/actions/test-parser
         with:
-          working-directory: ~/srcML-build
+          working-directory: ../srcML-build
           prefix: ${{ matrix.architecture }}.${{ matrix.os }}
 
       - name: Upload installer

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-15]
-        architecture: [Universal, x86_64, arm64]
+        architecture: [arm64] # [Universal, x86_64, arm64]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
@@ -19,23 +19,17 @@ jobs:
         with:
           cmakeVersion: 4.0
 
-      - name: Configure Universal
+      - name: Configure cmake for universal binary
         if: matrix.architecture == 'Universal'
         shell: bash
         run: |
           cmake --preset ci-macos
 
-      - name: Configure x86_64
-        if: matrix.architecture == 'x86_64'
+      - name: Configure cmake for single architecture binary
+        if: matrix.architecture != 'Universal'
         shell: bash
         run: |
-          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=x86_64
-
-      - name: Configure arm64
-        if: matrix.architecture == 'arm64'
-        shell: bash
-        run: |
-          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=arm64
+          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=${{ matrix.architecture }}
 
       - name: Build
         shell: bash
@@ -54,44 +48,29 @@ jobs:
         run: |
           sudo installer -dumplog -pkg srcml-*-macOS*.pkg -target /
 
-      - name: Run Installed srcml
+      - name: Run installed srcml
         shell: bash
         run: |
           srcml --version
           srcml --text="int a;" -l C++
 
       - name: Test client
-        working-directory: ../srcML-build
-        continue-on-error: true
-        shell: bash
-        run: |
-          ctest -R ^srcml -VV
-      - uses: actions/upload-artifact@v4
+        uses: ./.github/actions/test-client
         with:
-          name: ClientTest.${{ matrix.architecture }}.${{ matrix.os }}.log
-          path: build/Testing/Temporary/LastTest.log
+          working-directory: ~/srcML-build
+          prefix: ${{ matrix.os }}.${{ matrix.architecture }}
 
       - name: Test libsrcml
-        working-directory: ../srcML-build
-        continue-on-error: true
-        shell: bash
-        run: |
-          ctest -R ^libsrcml -VV
-      - uses: actions/upload-artifact@v4
+        uses: ./.github/actions/test-libsrcml
         with:
-          name: LibsrcmlTest.${{ matrix.architecture }}.${{ matrix.os }}.log
-          path: build/Testing/Temporary/LastTest.log
+          working-directory: ~/srcML-build
+          prefix: ${{ matrix.os }}.${{ matrix.architecture }}
 
       - name: Test parser
-        working-directory: ../srcML-build
-        continue-on-error: true
-        shell: bash
-        run: |
-          ninja run_parser_tests | tee ParserTest.log
-      - uses: actions/upload-artifact@v4
+        uses: ./.github/actions/test-parser
         with:
-          name: ParserTest.${{ matrix.installer }}.windows-latest.log
-          path: build/ParserTest.log
+          working-directory: ~/srcML-build
+          prefix: ${{ matrix.architecture }}.${{ matrix.os }}
 
       - name: Upload installer
         uses: actions/upload-artifact@v4

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -74,6 +74,6 @@ jobs:
         with:
           name: macOS ${{ matrix.architecture }} Package
           path: |
-            /Users/runner/work/srcML/srcML-build/dist/*.pkg
-            /Users/runner/work/srcML/srcML-build/dist/*.tar.gz
-            /Users/runner/work/srcML/srcML-build/dist/*.tar.bz2
+            build/dist/*.pkg
+            build/dist/*.tar.gz
+            build/dist/*.tar.bz2

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -70,36 +70,34 @@ jobs:
           ninja run_parser_tests
 
       - name: Clean
-        working-directory: ../srcML-build
         shell: bash
         run: |
-          ninja clean
+          rm -fR ../srcML-build
 
-      - name: Build
+      - name: Build x86_64
         shell: bash
         run: |
-          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=x86_64 -U CMAKE_OSX_ARCHITECTURES
+          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=x86_64
           cmake --build --preset ci-macos
 
-      - name: Package
+      - name: Package x86_64
         working-directory: ../srcML-build
         shell: bash
         run: |
           cpack
 
       - name: Clean
-        working-directory: ../srcML-build
         shell: bash
         run: |
-          ninja clean
+          rm -fR ../srcML-build
 
-      - name: Build
+      - name: Build arm64
         shell: bash
         run: |
-          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=arm64 -U CMAKE_OSX_ARCHITECTURES
+          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=arm64
           cmake --build --preset ci-macos
 
-      - name: Package
+      - name: Package arm64
         working-directory: ../srcML-build
         shell: bash
         run: |

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-15]
-        architecture: [arm64] # [Universal, x86_64, arm64]
+        architecture: [Universal, x86_64, arm64]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -23,13 +23,13 @@ jobs:
         if: matrix.architecture == 'Universal'
         shell: bash
         run: |
-          cmake --preset ci-macos
+          cmake -B build --preset ci-macos
 
       - name: Configure cmake for single architecture binary
         if: matrix.architecture != 'Universal'
         shell: bash
         run: |
-          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=${{ matrix.architecture }}
+          cmake -B build --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=${{ matrix.architecture }}
 
       - name: Build
         shell: bash
@@ -37,14 +37,13 @@ jobs:
           cmake --build --preset ci-macos
 
       - name: Package
+        working-directory: build
         shell: bash
         run: |
-          cd ../srcML-build
           cpack
 
       - name: Install package
         shell: bash
-        working-directory: ../srcML-build/dist
         run: |
           sudo installer -dumplog -pkg srcml-*-macOS*.pkg -target /
 
@@ -57,19 +56,16 @@ jobs:
       - name: Test client
         uses: ./.github/actions/test-client
         with:
-          working-directory: ../srcML-build
           prefix: ${{ matrix.os }}.${{ matrix.architecture }}
 
       - name: Test libsrcml
         uses: ./.github/actions/test-libsrcml
         with:
-          working-directory: ../srcML-build
           prefix: ${{ matrix.os }}.${{ matrix.architecture }}
 
       - name: Test parser
         uses: ./.github/actions/test-parser
         with:
-          working-directory: ../srcML-build
           prefix: ${{ matrix.architecture }}.${{ matrix.os }}
 
       - name: Upload installer

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -52,7 +52,7 @@ jobs:
         shell: bash
         working-directory: ../srcML-build/dist
         run: |
-          sudo installer -dumplog -pkg srcml-1.1.0-macOS.pkg -target /
+          sudo installer -dumplog -pkg srcml-*-macOS*.pkg -target /
 
       - name: Run Installed srcml
         shell: bash

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -29,12 +29,12 @@ jobs:
         if: matrix.architecture != 'Universal'
         shell: bash
         run: |
-          cmake -B build --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=${{ matrix.architecture }}
+          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=${{ matrix.architecture }} -B build
 
       - name: Build
         shell: bash
         run: |
-          cmake -B build --build --preset ci-macos
+          cmake --build build
 
       - name: Package
         working-directory: build

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash
         working-directory: ../srcML-build/dist
         run: |
-          sudo installer -dumplog -pkg srcml-1.0.0-macOS.pkg -target /
+          sudo installer -dumplog -pkg srcml-1.1.0-macOS.pkg -target /
 
       - name: Run Installed srcml
         shell: bash

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -1,15 +1,14 @@
 ---
 name: Build macOS
-
 on: workflow_dispatch
-
 jobs:
   build:
     strategy:
       matrix:
         os: [macos-15]
+        architecture: [Universal, x86_64, arm64]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
 
       - name: Checkout Repository
@@ -20,10 +19,23 @@ jobs:
         with:
           cmakeVersion: 4.0
 
-      - name: Configure
+      - name: Configure Universal
+        if: matrix.architecture == 'Universal'
         shell: bash
         run: |
           cmake --preset ci-macos
+
+      - name: Configure x86_64
+        if: matrix.architecture == 'x86_64'
+        shell: bash
+        run: |
+          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=x86_64
+
+      - name: Configure arm64
+        if: matrix.architecture == 'arm64'
+        shell: bash
+        run: |
+          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=arm64
 
       - name: Build
         shell: bash
@@ -54,6 +66,10 @@ jobs:
         shell: bash
         run: |
           ctest -R ^srcml -VV
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ClientTest.${{ matrix.architecture }}.${{ matrix.os }}.log
+          path: build/Testing/Temporary/LastTest.log
 
       - name: Test libsrcml
         working-directory: ../srcML-build
@@ -61,70 +77,26 @@ jobs:
         shell: bash
         run: |
           ctest -R ^libsrcml -VV
+      - uses: actions/upload-artifact@v4
+        with:
+          name: LibsrcmlTest.${{ matrix.architecture }}.${{ matrix.os }}.log
+          path: build/Testing/Temporary/LastTest.log
 
       - name: Test parser
         working-directory: ../srcML-build
         continue-on-error: true
         shell: bash
         run: |
-          ninja run_parser_tests
+          ninja run_parser_tests | tee ParserTest.log
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ParserTest.${{ matrix.installer }}.windows-latest.log
+          path: build/ParserTest.log
 
       - name: Upload installer
         uses: actions/upload-artifact@v4
         with:
-          name: macOS Universal Package
-          path: |
-            /Users/runner/work/srcML/srcML-build/dist/*.pkg
-            /Users/runner/work/srcML/srcML-build/dist/*.tar.gz
-            /Users/runner/work/srcML/srcML-build/dist/*.tar.bz2
-
-      - name: Clean
-        shell: bash
-        run: |
-          rm -fR ../srcML-build
-
-      - name: Build x86_64
-        shell: bash
-        run: |
-          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=x86_64
-          cmake --build --preset ci-macos
-
-      - name: Package x86_64
-        working-directory: ../srcML-build
-        shell: bash
-        run: |
-          cpack
-
-      - name: Upload installer
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS x86_64 Package
-          path: |
-            /Users/runner/work/srcML/srcML-build/dist/*.pkg
-            /Users/runner/work/srcML/srcML-build/dist/*.tar.gz
-            /Users/runner/work/srcML/srcML-build/dist/*.tar.bz2
-
-      - name: Clean
-        shell: bash
-        run: |
-          rm -fR ../srcML-build
-
-      - name: Build arm64
-        shell: bash
-        run: |
-          cmake --preset ci-macos -DCMAKE_OSX_ARCHITECTURES=arm64
-          cmake --build --preset ci-macos
-
-      - name: Package arm64
-        working-directory: ../srcML-build
-        shell: bash
-        run: |
-          cpack
-
-      - name: Upload installer
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS arm64 Package
+          name: macOS ${{ matrix.architecture }} Package
           path: |
             /Users/runner/work/srcML/srcML-build/dist/*.pkg
             /Users/runner/work/srcML/srcML-build/dist/*.tar.gz

--- a/.github/workflows/BuildMacOS.yml
+++ b/.github/workflows/BuildMacOS.yml
@@ -69,6 +69,12 @@ jobs:
         run: |
           ninja run_parser_tests
 
+      - name: Clean
+        working-directory: ../srcML-build
+        shell: bash
+        run: |
+          ninja clean
+
       - name: Build
         shell: bash
         run: |
@@ -80,6 +86,12 @@ jobs:
         shell: bash
         run: |
           cpack
+
+      - name: Clean
+        working-directory: ../srcML-build
+        shell: bash
+        run: |
+          ninja clean
 
       - name: Build
         shell: bash

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: build
         run: |
           export UseMultiToolTask=true
-          cmake .. --preset ci-msvc -DVCPKG_INSTALL_OPTIONS="--debug"
+          cmake .. --preset ci-msvc -DCMAKE_BUILD_TYPE=Release -DVCPKG_INSTALL_OPTIONS="--only-downloads"
 
       - name: Build
         shell: bash

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Windows Packages
+          name: "Windows Packages"
           path: |
             build/dist/*.msi
             build/dist/*.zip
@@ -163,7 +163,7 @@ jobs:
       - name: Download installer
         uses: actions/download-artifact@v4
         with:
-          name: installers
+          name: "Windows Packages"
 
       - name: Install package Wix msi
         if: ${{ matrix.installer == 'msi' }}

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -120,6 +120,18 @@ jobs:
           cmake "/c/Program Files/srcML/share/srcml/examples/libsrcml" -DsrcML_DIR="C:/Program Files/srcML/cmake" -G Ninja
           ninja
 
+      - name: Run examples in PowerShell (see loader errors)
+        shell: pwsh
+        working-directory: build2
+        continue-on-error: true
+        run: |
+          Get-ChildItem *.exe
+          foreach ($e in Get-ChildItem *.exe) {
+            Write-Host "== $($e.Name) =="
+            & .\${e.Name}
+            if ($LASTEXITCODE) { Write-Host "rc=$LASTEXITCODE" }
+          }
+
       - name: Run examples
         shell: bash
         working-directory: build2

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: build
         run: |
           export UseMultiToolTask=true
-          cmake .. --preset ci-msvc
+          cmake .. --preset ci-msvc -DVCPKG_INSTALL_OPTIONS="--debug"
 
       - name: Build
         shell: bash

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Install package Wix msi
         if: ${{ matrix.installer == 'msi' }}
         run: |
-          msiexec /i srcml-1.0.0-windows-x86_64.msi /quiet /norestart /L*vx .\msi.log
+          msiexec /i srcml-1.1.0-windows-x86_64.msi /quiet /norestart /L*vx .\msi.log
       - uses: actions/upload-artifact@v4
         with:
           name: msi.windows-latest.log
@@ -178,7 +178,7 @@ jobs:
         if: ${{ matrix.installer == 'inno' }}
         run: |
           dir
-          D:\a\srcML\srcML\srcml-1.0.0-windows-x86_64.exe /VERYSILENT /LOG="$GITHUB_WORKSPACE/inno.log"
+          D:\a\srcML\srcML\srcml-1.1.0-windows-x86_64.exe /VERYSILENT /LOG="$GITHUB_WORKSPACE/inno.log"
       - uses: actions/upload-artifact@v4
         with:
           name: inno.windows-latest.log
@@ -188,9 +188,9 @@ jobs:
         if: ${{ matrix.installer == 'nuget' }}
         run: |
           mkdir LocalNuGetFeed
-          nuget add srcml.1.0.0.nupkg -Source LocalNuGetFeed -Verbosity detailed -NonInteractive
+          nuget add srcml.1.1.0.nupkg -Source LocalNuGetFeed -Verbosity detailed -NonInteractive
           nuget install srcml -Source D:\a\srcML\srcML\LocalNuGetFeed -OutputDirectory "C:\Program Files" -Verbosity detailed -NonInteractive
-          mv "C:\Program Files\srcml.1.0.0" "C:\Program Files\srcML"
+          mv "C:\Program Files\srcml.1.1.0" "C:\Program Files\srcML"
 
       - name: Set PATH for Windows
         shell: bash

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     runs-on: windows-latest
     timeout-minutes: 30
+    environment: build
     steps:
 
       - name: Checkout Repository
@@ -19,6 +20,10 @@ jobs:
         uses: ./.github/actions/vcpkg
         with:
           vcpkg-ref: e140b1fde236eb682b0d47f905e65008a191800f
+          r2-access-key: ${{ secrets.R2_ACCESS_KEY }}
+          r2-secret-key: ${{ secrets.R2_SECRET_KEY }}
+          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
+          r2-endpoint: ${{ secrets.R2_ENDPOINT }}
 
       - name: Set up CMake
         uses: lukka/get-cmake@latest

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -7,10 +7,6 @@ jobs:
   build:
     runs-on: windows-latest
     timeout-minutes: 30
-    env:
-      VCPKG_FEATURE_FLAGS: manifests,binarycaching
-      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg-cache,readwrite
-
     steps:
 
       - name: Checkout Repository
@@ -18,15 +14,6 @@ jobs:
 
       - name: Setup Windows
         uses: microsoft/setup-msbuild@v1.3.1
-
-      - name: Restore vcpkg binary cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/vcpkg-cache
-          key: vcpkg-bin-${{ runner.os }}-x64-windows-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}-${{ inputs.vcpkg-ref || 'pinned' }}
-          restore-keys: |
-            vcpkg-bin-${{ runner.os }}-x64-windows-
-            vcpkg-bin-${{ runner.os }}-
 
       - name: Setup vcpkg
         uses: ./.github/actions/vcpkg

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -7,6 +7,10 @@ jobs:
   build:
     runs-on: windows-latest
     timeout-minutes: 30
+    env:
+      VCPKG_FEATURE_FLAGS: manifests,binarycaching
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg-cache,readwrite
+
     steps:
 
       - name: Checkout Repository
@@ -14,6 +18,15 @@ jobs:
 
       - name: Setup Windows
         uses: microsoft/setup-msbuild@v1.3.1
+
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/vcpkg-cache
+          key: vcpkg-bin-${{ runner.os }}-x64-windows-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}-${{ inputs.vcpkg-ref || 'pinned' }}
+          restore-keys: |
+            vcpkg-bin-${{ runner.os }}-x64-windows-
+            vcpkg-bin-${{ runner.os }}-
 
       - name: Setup vcpkg
         uses: ./.github/actions/vcpkg

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: build
         run: |
           export UseMultiToolTask=true
-          cmake .. --preset ci-msvc -DCMAKE_BUILD_TYPE=Release -DVCPKG_INSTALL_OPTIONS="--only-downloads"
+          cmake .. --preset ci-msvc
 
       - name: Build
         shell: bash

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: installers
+          name: Windows Packages
           path: |
             build/dist/*.msi
             build/dist/*.zip
@@ -234,33 +234,17 @@ jobs:
           export UseMultiToolTask=true
           cmake ../test -DSRCML_TEST_INSTALLED=ON -G Ninja
 
-      - name: Windows Client Tests on Installed srcml
-        shell: bash
-        working-directory: build
-        timeout-minutes: 10
-        continue-on-error: true
-        run: |
-          ctest -C Release -VV -R ^srcml
-
-      - uses: actions/upload-artifact@v4
+      - name: Test client
+        uses: ./.github/actions/test-client
         with:
-          name: ClientTest.${{ matrix.installer }}.windows-latest.log
-          path: build/Testing/Temporary/LastTest.log
+          prefix: "Windows ${{ matrix.installer }}"
 
-      - name: Generate Parser Tests
-        shell: bash
-        working-directory: build
-        continue-on-error: true
-        run: |
-          cmake --build . --target gen_parser_tests
-
-      - name: Run Parser Tests
-        shell: bash
-        working-directory: build
-        continue-on-error: true
-        run: |
-          cmake --build . --target run_parser_tests | tee ParserTest.log
-      - uses: actions/upload-artifact@v4
+      - name: Test libsrcml
+        uses: ./.github/actions/test-libsrcml
         with:
-          name: ParserTest.${{ matrix.installer }}.windows-latest.log
-          path: build/ParserTest.log
+          prefix: "Windows ${{ matrix.installer }}"
+
+      - name: Test parser
+        uses: ./.github/actions/test-parser
+        with:
+          prefix: "Windows ${{ matrix.installer }}"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,12 @@
+# CHANGES
+
+This release of srcml is a drop-in replacement for the previous srcml client and libsrcml library. Except for Python, v1.1.0 does not make any changes to the markup for C, C++, Java, and C#. It does fix many markup bugs.
+
+It includes:
+
+* In addition to C, C++, C#, and Java, 1.0.0 markup for the Python programming language
+* New query language srcQL, which allows querying by using code statements and includes unification, e.g., `FIND $T $N = new $T()`
+* New output format for source with null separators (similar to `find`) and an optional YAML header with attributes and namespaces
+* Additional libsrcml functions, including per-language versions, srcql, and full control of attributes and namespaces for units and archives
+* Multiple bug fixes, including more accurate line/column position
+* Many build improvements

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,59 @@
 
 This release of srcml is a drop-in replacement for the previous srcml client and libsrcml library. Except for Python, v1.1.0 does not make any changes to the markup for C, C++, Java, and C#. It does fix many markup bugs.
 
-It includes:
+Major additions are:
 
-* In addition to C, C++, C#, and Java, 1.0.0 markup for the Python programming language
+* 1.0.0 markup for the Python programming language
 * New query language srcQL, which allows querying by using code statements and includes unification, e.g., `FIND $T $N = new $T()`
 * New output format for source with null separators (similar to `find`) and an optional YAML header with attributes and namespaces
-* Additional libsrcml functions, including per-language versions, srcql, and full control of attributes and namespaces for units and archives
+* Additional libsrcml functions, including per-language versions, srcql, and complete control of attributes and namespaces for units and archives (see below)
 * Multiple bug fixes, including more accurate line/column position
-* Many build improvements
+* Many build and packaging improvements
+
+## libsrcml
+
+The v1.1.0 libsrcml API supports all v1.0.0 libsrcml functions with no changes. The following are additional functions in the v1.1.0 libsrcml API. See the include file _srcml.h_ for more details.
+
+```C
+// per-language markup versions
+int srcml_markup_version_number(const char* language);
+const char* srcml_markup_version_string(const char* language);
+
+// libsrcml version (separate from client version)
+int srcml_libsrcml_version_number();
+const char* srcml_libsrcml_version_string();
+
+// srcql queries
+int srcml_append_transform_srcql(struct srcml_archive* archive, const char* srcql_string);
+int srcml_append_transform_srcql_attribute(struct srcml_archive* archive, const char* srcql_string,
+int srcml_append_transform_srcql_element(struct srcml_archive* archive, const char* srcql_string,
+
+// direct access to a unit's source
+const char* srcml_unit_get_src(struct srcml_unit* unit);
+ssize_t srcml_unit_get_src_size(struct srcml_unit* unit);
+
+// attributes for units, archives, and convenience functions
+int srcml_unit_add_attribute(struct srcml_unit* unit, const char* uri, const char* name, const char* value);
+size_t srcml_unit_get_attribute_size(const struct srcml_unit* unit);
+const char* srcml_unit_get_attribute_prefix(const struct srcml_unit* unit, size_t pos);
+const char* srcml_unit_get_attribute_name(const struct srcml_unit* unit, size_t pos);
+const char* srcml_unit_get_attribute_value(const struct srcml_unit* unit, size_t pos);
+int srcml_archive_add_attribute(struct srcml_archive* archive, const char* uri, const char* name, const char* value);
+size_t srcml_archive_get_attribute_size(const struct srcml_archive* archive);
+const char* srcml_archive_get_attribute_prefix(const struct srcml_archive* archive, size_t pos);
+const char* srcml_archive_get_attribute_name(const struct srcml_archive* archive, size_t pos);
+const char* srcml_archive_get_attribute_value(const struct srcml_archive* archive, size_t pos);
+int srcml_add_attribute(const char* uri, const char* name, const char* value);
+size_t srcml_get_attribute_size();
+const char* srcml_get_attribute_prefix(size_t pos);
+const char* srcml_get_attribute_name(size_t pos);
+const char* srcml_get_attribute_value(size_t pos);
+
+// namespaces for a unit
+int srcml_unit_register_namespace(struct srcml_unit* unit, const char* prefix, const char* uri);
+size_t srcml_unit_get_namespace_size(const struct srcml_unit* unit);
+const char* srcml_unit_get_namespace_prefix(const struct srcml_unit* unit, size_t pos);
+const char* srcml_unit_get_prefix_from_uri(const struct srcml_unit* unit, const char* namespace_uri);
+const char* srcml_unit_get_namespace_uri(const struct srcml_unit* unit, size_t pos);
+const char* srcml_unit_get_uri_from_prefix(const struct srcml_unit* unit, const char* prefix);
+```

--- a/doc/manpage/CMakeLists.txt
+++ b/doc/manpage/CMakeLists.txt
@@ -30,7 +30,7 @@ add_custom_target(publish_manpage COMMAND rsync --inplace ${CMAKE_BINARY_DIR}/sr
 find_program(PANDOC_EXE REQUIRED NAMES pandoc pandoc.exe)
 
 # Configure file properties used to configure the file srcml.cfg
-set(CLIENT_VERSION "1.0.0")
+set(CLIENT_VERSION "1.1.0")
 set(HELP_FLAG_LONG "help")
 set(HELP_FLAG_SHORT "h")
 set(VERSION_FLAG_LONG "version")

--- a/doc/manpage/srcml.cfg
+++ b/doc/manpage/srcml.cfg
@@ -485,8 +485,7 @@ Report bugs at Contact us at http://www.srcml.org/support.html
 
 # AUTHORS
 
-Written by Michael L. Collard, Michael Decker, Drew Guarnera, Brian Bartman,
-and Heather Michaud.
+Written by Michael L. Collard, Michael Decker, Kyle Rossi, Joshua Behler, Drew Guarnera, Brian Bartman, and Heather Michaud.
 
 # COPYRIGHT
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -32,35 +32,35 @@
 #   SRCML_BAKE_SRC="https://github.com/srcML/srcML.git"
 #   SRCML_BAKE_SRC="https://github.com/srcML/srcML.git#develop"
 variable "SRCML_BAKE_SRC" {
-  # description = "Location of the source code"
+  description = "Location of the source code"
   default = "https://github.com/srcML/srcML.git#v1.1.0-beta"
 }
 
 # Override using the environment variable SRCML_BAKE_PRESET_SUFFIX
 # E.g., SRCML_BAKE_PRESET_SUFFIX="-fast"
 variable "SRCML_BAKE_PRESET_SUFFIX" {
-  # description = "Suffix for the workflow preset"
+  description = "Suffix for the workflow preset"
   default = ""
 }
 
 # Override using the environment variable SRCML_BAKE_ARCHITECTURE
 # E.g., SRCML_BAKE_ARCHITECTURE="linux/arm64"
 variable "SRCML_BAKE_ARCHITECTURE" {
-  # description = "Architectures to build on"
+  description = "Architectures to build on"
   default = "linux/amd64,linux/arm64"
 }
 
 # Override using the environment variable SRCML_BAKE_DESTINATION_DIR
 # E.g., SRCML_BAKE_DESTINATION_DIR="../dists"
 variable "SRCML_BAKE_DESTINATION_DIR" {
-  # description = "Local directory for export of packages"
+  description = "Local directory for export of packages"
   default = "./dist_packages"
 }
 
 # Override using the environment variable SRCML_BAKE_CONTEXT_DIR
 # E.g., SRCML_BAKE_CONTEXT_DIR="~/srcML/docker"
 variable "SRCML_BAKE_CONTEXT_DIR" {
-  # description = "Directory of context files"
+  description = "Directory of context files"
   default = "./docker"
 }
 
@@ -68,7 +68,7 @@ variable "SRCML_BAKE_CONTEXT_DIR" {
 #   SRCML_BAKE_REGISTRY=""         docker buildx bake # Docker Hub
 #   SRCML_BAKE_REGISTRY="ghcr.io"  docker buildx bake # GitHub Container Registry
 variable "SRCML_BAKE_REGISTRY" {
-  # description = "Registry domain for default build environments"
+  description = "Registry domain for default build environments"
   default = ""
 }
 
@@ -76,19 +76,19 @@ variable "SRCML_BAKE_REGISTRY" {
 #   SRCML_BAKE_PACKAGE_REGISTRY=""         docker buildx bake # Docker Hub
 #   SRCML_BAKE_PACKAGE_REGISTRY="ghcr.io"  docker buildx bake # GitHub Container Registry
 variable "SRCML_BAKE_PACKAGE_REGISTRY" {
-  # description = "Registry domain for the package targets, package and log"
+  description = "Registry domain for the package targets, package and log"
   default = "ghcr.io"
 }
 
 # Placeholder to redefine in docker-bake.override.hcl
 variable "SRCML_BAKE_SRCML_VERSION" {
-  # description = "srcML version to embed in image data"
+  description = "srcML version to embed in image data"
   default = ""
 }
 
 # Placeholder to redefine in docker-bake.override.hcl
 variable "SRCML_BAKE_CMAKE_VERSION" {
-  # description = "CMake version"
+  description = "CMake version"
   default = ""
 }
 
@@ -96,7 +96,7 @@ variable "SRCML_BAKE_CMAKE_VERSION" {
 # E.g., SRCML_BAKE_CACHE=type=local,src=bake_cache,dest=bake_cache
 # E.g., SRCML_BAKE_CACHE=""
 variable "SRCML_BAKE_CACHE" {
-  # description = "Cache for build layers"
+  description = "Cache for build layers"
   default = ""
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -164,32 +164,6 @@ EOF
   # cache-to   = ["type=local,dest=./.docker-build-cache/${targetName(dist)},mode=max"]
 }
 
-# Dockerfile to build the package
-# The overall workflow preset is separated into the various stages. That way if the cache
-# for a layer is invalidated, it is not the entire workflow. The three testing stages all
-# are from the result of the package and install, and can be done in parallel.
-# The use of multiple stages allows for fine-grained cache invalidation
-function "builderStage" {
-  params = [dist]
-  result = <<EOF
-FROM ${tagName(dist)} AS builder
-WORKDIR /src
-ADD --link ["${SRCML_BAKE_SRC}", "."]
-# RUN cmake --workflow --preset ${workflowPreset(dist)}
-RUN cmake --preset ${workflowPreset(dist)}
-RUN cmake --build --preset ${workflowPreset(dist)}
-FROM builder AS packager
-RUN cpack --preset ${workflowPreset(dist)}
-RUN cmake --build --preset ci-install-package-${dist.workflow}
-FROM packager AS test_client
-RUN cmake --build --preset ci-test-client-${dist.workflow}
-FROM packager AS test_libsrcml
-RUN cmake --build --preset ci-test-libsrcml-${dist.workflow}
-FROM packager AS test_parser
-RUN cmake --build --preset ci-test-parser-${dist.workflow}
-EOF
-}
-
 # Packages for all distributions
 # Output to host directory ${SRCML_BAKE_DESTINATION_DIR}
 # Create image whose only contents are the package
@@ -207,24 +181,20 @@ EOF
   matrix = {
     dist = distributions
   }
-  dockerfile-inline = builderStage(dist)
+  dockerfile-inline = <<EOF
+FROM ${tagName(dist)} AS builder
+WORKDIR /src
+ADD --link ["${SRCML_BAKE_SRC}", "."]
+# RUN cmake --workflow --preset ${workflowPreset(dist)}
+RUN cmake --preset ${workflowPreset(dist)}
+RUN cmake --build --preset ${workflowPreset(dist)}
+FROM builder AS packager
+RUN cpack --preset ${workflowPreset(dist)}
+RUN cmake --build --preset ci-install-package-${dist.workflow}
+EOF
   tags     = [categoryTagName(dist, "build")]
   # output   = ["type=docker"]
   inherits = ["base"]
-}
-
-# Extract the installers
-function "installerStage" {
-  params = []
-  result = <<EOF
-FROM scratch AS dist
-COPY --from="packager" \
-  /src-build/dist/*.rpm \
-  /src-build/dist/*.deb \
-  /src-build/dist/*.tar.gz \
-  /src-build/dist/*.bz2 \
-  /
-EOF
 }
 
 # Packages for all distributions
@@ -233,6 +203,12 @@ EOF
 target "package" {
   name = categoryTarget(dist, "package")
   description = "srcML package for ${dist.name}"
+  contexts = {
+    build = "target:${categoryTarget(dist, "build")}"
+  }
+  depends-on = [
+    categoryTarget(dist, "build"),
+  ]
   labels = {
     "org.opencontainers.image.title" = "srcML ${dist.name} Package Files"
     "org.opencontainers.image.description" = <<EOF
@@ -243,11 +219,90 @@ EOF
     dist = distributions
   }
   dockerfile-inline = <<EOF
-${builderStage(dist)}
-${installerStage()}
+FROM scratch AS dist
+COPY --from="build" \
+  /src-build/dist/*.rpm \
+  /src-build/dist/*.deb \
+  /src-build/dist/*.tar.gz \
+  /src-build/dist/*.bz2 \
+  /
 EOF
   tags     = [categoryTagName(dist, "package")]
   output   = ["type=local,dest=${SRCML_BAKE_DESTINATION_DIR}"]
+  no-cache = true
+  inherits = ["base"]
+}
+
+# Individual test targets
+target "test-client" {
+  name = categoryTarget(dist, "test-client")
+  description = "srcML client test for ${dist.name}"
+  labels = {
+    "org.opencontainers.image.title" = "srcML ${dist.name} Client Test"
+    "org.opencontainers.image.description" = <<EOF
+The srcML client test for ${dist.name}.
+EOF
+  }
+  matrix = {
+    dist = distributions
+  }
+  depends_on = [categoryTarget(dist, "build")]
+  contexts = {
+    packager = "target:${categoryTarget(dist, "build")}"
+  }
+  dockerfile-inline = <<EOF
+FROM packager AS test_client
+RUN cmake --build --preset ci-test-client-${dist.workflow}
+EOF
+  tags     = [categoryTagName(dist, "test-client")]
+  inherits = ["base"]
+}
+
+target "test-libsrcml" {
+  name = categoryTarget(dist, "test-libsrcml")
+  description = "srcML libsrcml test for ${dist.name}"
+  labels = {
+    "org.opencontainers.image.title" = "srcML ${dist.name} libsrcml Test"
+    "org.opencontainers.image.description" = <<EOF
+The srcML libsrcml test for ${dist.name}.
+EOF
+  }
+  matrix = {
+    dist = distributions
+  }
+  depends_on = [categoryTarget(dist, "build")]
+  contexts = {
+    packager = "target:${categoryTarget(dist, "build")}"
+  }
+  dockerfile-inline = <<EOF
+FROM packager AS test_libsrcml
+RUN cmake --build --preset ci-test-libsrcml-${dist.workflow}
+EOF
+  tags     = [categoryTagName(dist, "test-libsrcml")]
+  inherits = ["base"]
+}
+
+target "test-parser" {
+  name = categoryTarget(dist, "test-parser")
+  description = "srcML parser test for ${dist.name}"
+  labels = {
+    "org.opencontainers.image.title" = "srcML ${dist.name} Parser Test"
+    "org.opencontainers.image.description" = <<EOF
+The srcML parser test for ${dist.name}.
+EOF
+  }
+  matrix = {
+    dist = distributions
+  }
+  depends_on = [categoryTarget(dist, "build")]
+  contexts = {
+    packager = "target:${categoryTarget(dist, "build")}"
+  }
+  dockerfile-inline = <<EOF
+FROM packager AS test_parser
+RUN cmake --build --preset ci-test-parser-${dist.workflow}
+EOF
+  tags     = [categoryTagName(dist, "test-parser")]
   inherits = ["base"]
 }
 
@@ -255,26 +310,28 @@ EOF
 # Output to host directory ${SRCML_BAKE_DESTINATION_DIR}
 target "log" {
   name = categoryTarget(dist, "log")
-  description = "srcML package log for ${dist.name}"
-  labels = {
-    "org.opencontainers.image.title" = "srcML ${dist.name} Test Logs"
-    "org.opencontainers.image.description" = <<EOF
-The srcML test log for ${dist.name}.
-EOF
+  matrix = { dist = distributions }
+  contexts = {
+    # Reference specific stages from the build target
+    test-client = "target:${categoryTarget(dist, "test-client")}"
+    test-parser = "target:${categoryTarget(dist, "test-parser")}"
+    test-libsrcml = "target:${categoryTarget(dist, "test-libsrcml")}"
   }
-  matrix = {
-    dist = distributions
-  }
+  depends-on = [
+    categoryTarget(dist, "test-client"),
+    categoryTarget(dist, "test-parser"),
+    categoryTarget(dist, "test-libsrcml")
+  ]
   dockerfile-inline = <<EOF
-${builderStage(dist)}
 FROM scratch AS dist
-COPY --from=test_client /src-build/dist/*.log /
-COPY --from=test_parser /src-build/dist/*.log /
-COPY --from=test_libsrcml /src-build/dist/*.log /
+COPY --from=test-client /src-build/dist/*.log /
+COPY --from=test-parser /src-build/dist/*.log /
+COPY --from=test-libsrcml /src-build/dist/*.log /
 EOF
-  tags      = [categoryTagName(dist, "log")]
-  output    = ["type=local,dest=${SRCML_BAKE_DESTINATION_DIR}"]
-  inherits  = ["base"]
+  tags = [categoryTagName(dist, "log")]
+  output = ["type=local,dest=${SRCML_BAKE_DESTINATION_DIR}"]
+  no-cache = true
+  inherits = ["base"]
 }
 
 target "image" {
@@ -289,9 +346,20 @@ EOF
   matrix = {
     dist = distributions
   }
+  contexts = {
+    build = "target:${categoryTarget(dist, "build")}"
+  }
+  depends-on = [
+    categoryTarget(dist, "build"),
+  ]
   dockerfile-inline = <<EOF
-${builderStage(dist)}
-${installerStage()}
+FROM scratch AS dist
+COPY --from="build" \
+  /src-build/dist/*.rpm \
+  /src-build/dist/*.deb \
+  /src-build/dist/*.tar.gz \
+  /src-build/dist/*.bz2 \
+  /
 EOF
   tags     = [categoryTagName(dist, "image")]
   # output   = ["type=registry"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -33,7 +33,7 @@
 #   SRCML_BAKE_SRC="https://github.com/srcML/srcML.git#develop"
 variable "SRCML_BAKE_SRC" {
   # description = "Location of the source code"
-  default = "https://github.com/srcML/srcML.git#develop"
+  default = "https://github.com/srcML/srcML.git#v1.1.0-beta"
 }
 
 # Override using the environment variable SRCML_BAKE_PRESET_SUFFIX

--- a/docker-bake.override.hcl
+++ b/docker-bake.override.hcl
@@ -56,7 +56,7 @@ variable "SRCML_BAKE_CMAKE_VERSION" {
 # E.g., SRCML_BAKE_SRCML_VERSION="1.1.0"
 variable "SRCML_BAKE_SRCML_VERSION" {
   # description = "srcML version to embed in image data"
-  default = "1.0.0"
+  default = "1.1.0"
 }
 
 # Ubuntu build images

--- a/docker-bake.override.hcl
+++ b/docker-bake.override.hcl
@@ -7,7 +7,7 @@
 #
 # The main target groups are `default` (image for the srcML build environment) and `build` (build
 # and package srcML). The rest of the groups are to extract the srcML installer packages: `image`,
-# `files`, and `logs`. See docker-bake.hcl for details.
+# `package`, and `log`. See docker-bake.hcl for details.
 #
 # In addition to these targets for all distributions, there are targets to narrow the focus down to
 # specific distributions, specific versions of those distributions, and specific target groups:
@@ -91,13 +91,13 @@ group "ubuntu_build" { targets = categoryDistributionTarget("ubuntu", "build") }
 # Example target name: ubuntu_24_04_package Example tag: srcml/ubuntu_image:24.04
 group "ubuntu_image" { targets = categoryDistributionTarget("ubuntu", "image") }
 
-# Ubuntu package files
-# Example target name: ubuntu_24_04_files Example tag: srcml/ubuntu_files:24.04
-group "ubuntu_files" { targets = categoryDistributionTarget("ubuntu", "files") }
+# Ubuntu package package
+# Example target name: ubuntu_24_04_package Example tag: srcml/ubuntu_package:24.04
+group "ubuntu_package" { targets = categoryDistributionTarget("ubuntu", "package") }
 
-# Ubuntu logs images
-# Example target name: ubuntu_24_04_logs Example tag: srcml/ubuntu_logs:24.04
-group "ubuntu_logs" { targets = categoryDistributionTarget("ubuntu", "logs") }
+# Ubuntu log images
+# Example target name: ubuntu_24_04_log Example tag: srcml/ubuntu_log:24.04
+group "ubuntu_log" { targets = categoryDistributionTarget("ubuntu", "log") }
 
 # Fedora build images
 # Example target name: fedora_build_42 Example tag: srcml/_buildfedora:42
@@ -117,14 +117,14 @@ group "fedora_image" { targets = categoryDistributionTarget("fedora", "image") }
 # Tumbleweed target name: opensuse_tumbleweed Tumbleweed tag: srcml/opensuse:tumbleweed
 group "opensuse_image" { targets = categoryDistributionTarget("opensuse", "image") }
 
-# Fedora logs images
-# Example target name: fedora_logs_42 Example tag: srcml/_logsfedora:42
-group "fedora_logs" { targets = categoryDistributionTarget("fedora", "logs") }
+# Fedora log images
+# Example target name: fedora_log_42 Example tag: srcml/_logfedora:42
+group "fedora_log" { targets = categoryDistributionTarget("fedora", "log") }
 
-# OpenSUSE logs images
-# Example target name: opensuse_logs_15_6 Example tag: srcml/_logsopensuse:15.6
+# OpenSUSE log images
+# Example target name: opensuse_log_15_6 Example tag: srcml/_logopensuse:15.6
 # Tumbleweed target name: opensuse_tumbleweed Tumbleweed tag: srcml/opensuse:tumbleweed
-group "opensuse_logs" { targets = categoryDistributionTarget("opensuse", "logs") }
+group "opensuse_log" { targets = categoryDistributionTarget("opensuse", "log") }
 
 # Specific distribution with category
 function "distributionTarget" {

--- a/docker-bake.override.hcl
+++ b/docker-bake.override.hcl
@@ -21,7 +21,7 @@
 # All supported Linux distributions
 # NOTE: Any distributions added or deleted must be reflected in the services in compose.yml
 variable "distributions" {
-  # description = "Table of supported Linux distributions (see docker-bake.override.hcl)"
+  description = "Table of supported Linux distributions"
   default = [
     { id = "ubuntu",   version_id = "25.04",  java_version_id="22.04", name = "Ubuntu 25.04", workflow = "ubuntu", java = "latest", tag = "latest" },
     { id = "ubuntu",   version_id = "24.10",  java_version_id="22.04", name = "Ubuntu 24.10", workflow = "ubuntu", java = "latest"},
@@ -48,14 +48,14 @@ variable "distributions" {
 # Override using the environment variable SRCML_BAKE_CMAKE_VERSION
 # E.g., SRCML_BAKE_CMAKE_VERSION="3.31.6"
 variable "SRCML_BAKE_CMAKE_VERSION" {
-  # description = "CMake version"
+  description = "CMake version"
   default = "4.0.0"
 }
 
 # Override using the environment variable SRCML_BAKE_SRCML_VERSION
 # E.g., SRCML_BAKE_SRCML_VERSION="1.1.0"
 variable "SRCML_BAKE_SRCML_VERSION" {
-  # description = "srcML version to embed in image data"
+  description = "srcML version to embed in image data"
   default = "1.1.0"
 }
 

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -120,7 +120,6 @@ message(STATUS "CPack generators: ${CPACK_GENERATOR}")
 get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)
 list(REMOVE_ITEM CPACK_COMPONENTS_ALL "LOCAL")
 
-message(STATUS "CPACK_PACKAGE_NAME: ${CPACK_PACKAGE_NAME}")
 message(STATUS "CPACK_GENERATOR: ${CPACK_GENERATOR}")
 
 # needs to be last so not overwritten

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -90,13 +90,13 @@ function(add_workflow_test_targets binary_dir output_directory package_file_name
     # Target for test_client
     add_custom_target(test_client
         WORKING_DIRECTORY ${binary_dir}
-        COMMAND ${CMAKE_CTEST_COMMAND} -R ^srcml --timeout ${SRCML_TEST_TIMEOUT} --output-log ${output_directory}/${package_file_name}-client.log || true
+        COMMAND ${CMAKE_CTEST_COMMAND} -VV -R ^srcml --timeout ${SRCML_TEST_TIMEOUT} --output-log ${output_directory}/${package_file_name}-client.log || true
     )
 
     # Target for test_libsrcml
     add_custom_target(test_libsrcml
         WORKING_DIRECTORY ${binary_dir}
-        COMMAND ${CMAKE_CTEST_COMMAND} -R ^libsrcml --timeout ${SRCML_TEST_TIMEOUT} --output-log ${output_directory}/${package_file_name}-libsrcml.log || true
+        COMMAND ${CMAKE_CTEST_COMMAND} -VV -R ^libsrcml --timeout ${SRCML_TEST_TIMEOUT} --output-log ${output_directory}/${package_file_name}-libsrcml.log || true
     )
 
     # Target for test_parser

--- a/presets/CMakeMSVCPresets.json
+++ b/presets/CMakeMSVCPresets.json
@@ -10,67 +10,17 @@
       "description": "Default build options for MSVC",
       "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" },
       "toolchainFile": "toolchain-msvc.cmake",
-      // "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "cl",
         "CMAKE_C_COMPILER": "cl",
-        // /Wall
-        // /D_CRT_SECURE_NO_WARNINGS  # disable strcpy() warnings
-        // /D_CRT_NONSTDC_NO_WARNINGS # disable read() warnings
-        // /wd4068 # unknown pragma
-        // # /wd4101 # unreferenced local variable
-        // # /wd4519 # unmarked inlining notification warning
-        // /wd4514 # removed inline function not called (in one context)
-        // # /wd4668 # preprocessor symbol not defined but used in an #if
-        // /wd4710 # unmarked inlining notification warning
-        // /wd4820 # byte padding
-        // /wd5039 # pointer or reference to potentially throwing function passed to 'extern "C"' function under -EHc
-        // /wd4711 # selected for automatic inline expansion
-        // /wd4706 # assigment within conditional expression
-        // /wd4625 # copy constructor was implicitly defined as deleted
-        // /wd4626 # assignment operator was implicitly defined as deleted
-        // /wd5026 # move constructor was implicitly defined as deleted
-        // /wd5027 # move assignment operator was implicitly defined as deleted
-        // /wd4668 # is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
-        // /wd4868 # compiler may not enforce left-to-right evaluation order in braced initializer list
-        // /wd4371 # layout of class may have changed from a previous version of the compiler due to better packing of member
-        // /wd4623 # default constructor was implicitly defined as deleted
-        // /wd5045 # Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
         "CMAKE_CXX_FLAGS": "/Wall /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_WARNINGS /wd4068 /wd4514 /wd4710 /wd4820 /wd5039 /wd4711 /wd4706 /wd4625 /wd4626 /wd5026 /wd5027 /wd4668 /wd4868 /wd4371 /wd4623 /wd5045 ",
-        // With MSVC, interprocedural optimization leads to a 10x static library, with only a slight reduction in size for the dynamic library
-        // /wd4355 # 'this' used in base member initializer list
-        // /wd4866 # compiler may not enforce left-to-right evaluation order for call to 'operator<<'
-        // /wd5204 # 'Concurrency::details::_DefaultPPLTaskScheduler': class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
-        // /wd5264 # 'int const `void __cdecl srcml_display_metadata(srcml_request_t const &,std::vector<srcml_input_src,std::allocator<srcml_input_src> > const &,srcml_input_src const &)'::`2'::display_commands': 'const' variable is not used
-        // /wd4577 # 'noexcept' used with no exception handling mode specified; termination on exception is not guaranteed. Specify /EHsc
         "SRCML_GLOBAL_COMPILE_OPTIONS": "/wd4355;/wd4866;/wd5204;/wd5264;/wd4577",
         "SRCML_GLOBAL_LINK_OPTIONS": "",
-        // /wd4242 # 'argument': conversion from 'T' to '_Elem', possible loss of data
-        // /wd4244 # 'argument': conversion from '<type1>' to '<type2>', possible loss of data
-        // /wd4267 # 'return': conversion from 'size_t' to 'unsigned int', possible loss of data
-        // /wd4355 # this': used in base member initializer list
-        // /wd4365 # 'argument': conversion from 'size_t' to 'const __int64', signed/unsigned mismatch
-        //         # conversion from 'int' to 'unsigned int',
-        // /wd4477 # 'sprintf' : format string '%u' requires an argument of type 'unsigned int', but variadic argument 1 has type 'size_t'
-        // /wd4530 # C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
-        // /wd4577 # 'noexcept' used with no exception handling mode specified; termination on exception is not guaranteed. Specify /EHsc
-        // /wd4100: 'param': unreferenced formal parameter
         "SRCML_ANTLR_DISABLED_WARNINGS": "/wd5267;/wd4242;/wd4244;/wd4267;/wd4355;/wd4365;/wd4477;/wd4530;/wd4577;/wd4100",
-        // /wd4267 # 'return': conversion from 'size_t' to 'unsigned int', possible loss of data
-        // /wd4365 # 'argument': conversion from 'size_t' to 'const __int64', signed/unsigned mismatch
-        //         # conversion from 'int' to 'unsigned int',
-        // /wd4459 # declaration of 'context' hides global declaration
-        // /wd4530 # C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
-        // /wd4577 # 'noexcept' used with no exception handling mode specified; termination on exception is not guaranteed. Specify /EHsc
-        // /wd4701 # potentially uninitialized local variable '...' used
-        // /wd5262 # implicit fall-through occurs here; are you missing a break statement? Use [[fallthrough]] when a break statement is intentionally omitted between cases
-        // /wd5264 # 'int const `char const * __cdecl `anonymous namespace'::positoa(int)'::`2'::SIZE': 'const' variable is not used
         "SRCML_PARSER_DISABLED_WARNINGS": "/wd4267;/wd4365;/wd4459;/wd4530;/wd4577;/wd4701;/wd5262;/wd5264",
         "SRCML_LIBSRCML_COMPILE_FLAGS": "/Zi",
         "SRCML_LIBSRCML_SHARED_LINK_FLAGS_RELEASE": "/DEBUG /OPT:REF /OPT:ICF",
         "SRCML_LIBSRCML_STATIC_LINK_FLAGS_RELEASE": "/LTCG:OFF",
-        // wd4355 # this': used in base member initializer list
-        // wd5204 # class has virtual functions, but its trivial destructor is not virtual
         "SRCML_CLIENT_COMPILE_FLAGS": "/wd4355;/wd5204",
         "SRCML_CLIENT_LINK_FLAGS": ""
       }

--- a/presets/CMakeMacOSPresets.json
+++ b/presets/CMakeMacOSPresets.json
@@ -18,14 +18,11 @@
       "inherits": ["ci-macos-only", "ci-clang", "ci-sibling-build"],
       "generator": "Ninja",
       "cacheVariables": {
-        // srcml client searches for libsrcml in current directory, sibling lib/ directory, or /usr/local/lib
         "CMAKE_INSTALL_RPATH": "@loader_path;@loader_path/../lib;/usr/local/lib",
         "CMAKE_INSTALL_RPATH_USE_LINK_PATH": "TRUE",
-        // Making the exported_symbols_list an empty file reduces size of executable, as strip does not work
         "SRCML_CLIENT_LINK_FLAGS": "-exported_symbols_list /dev/null",
         "SRCML_ANTLR_COMPILE_FLAGS": "-Wno-system-headers;-Wno-deprecated-declarations;-Wno-format",
         "CMAKE_BUILD_TYPE": "Release",
-        // Build for both x86 and arm64
         "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "10.15",
         "BUILD_LIBSRCML_TESTS": "ON",
@@ -42,7 +39,6 @@
       "hidden": true,
       "cacheVariables": {
         "CPACK_GENERATOR": "productbuild;TGZ;TBZ2",
-        // Making the exported_symbols_list an empty file reduces size of executable, as strip does not work
         "SRCML_CLIENT_LINK_FLAGS": "-exported_symbols_list /dev/null",
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON",

--- a/presets/CMakeRPMPresets.json
+++ b/presets/CMakeRPMPresets.json
@@ -23,7 +23,6 @@
       "description": "Default build options for RPM release",
       "inherits": ["ci-base", "ci-rpm-only", "ci-gcc", "ci-sibling-build"],
       "cacheVariables": {
-        // srcml client searches for libsrcml in current directory, sibling lib/ directory
         "CMAKE_INSTALL_RPATH": "$ORIGIN;$ORIGIN/../lib"
       }
     }

--- a/src/client/srcml.cpp
+++ b/src/client/srcml.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
         std::cout << "srcml: " << SRCML_CLIENT_VERSION_STRING << '\n'
                   << "libsrcml: " << srcml_libsrcml_version_string() << '\n';
 
-        std::cout << "markup: " << '\n';
+        std::cout << "markup:" << '\n';
 
         // output Python support first
         for (size_t i = 0; i < srcml_get_language_list_size(); ++i) {

--- a/src/client/srcml.cpp
+++ b/src/client/srcml.cpp
@@ -38,8 +38,8 @@ namespace {
     bool request_create_src        (const srcml_request_t&);
 }
 
-const int SRCML_CLIENT_VERSION_NUMBER = 10000;
-const char* SRCML_CLIENT_VERSION_STRING = "1.0.0";
+const char* SRCML_CLIENT_VERSION_STRING = "1.1.0";
+const int SRCML_CLIENT_VERSION_NUMBER = 10100;
 
 int main(int argc, char* argv[]) {
 
@@ -54,13 +54,15 @@ int main(int argc, char* argv[]) {
     // version
     if (option(SRCML_COMMAND_VERSION)) {
 
+        // output the client and libsrcml versions
+        std::cout << "srcml client: " << SRCML_CLIENT_VERSION_STRING << '\n'
+                  << "libsrcml: " << srcml_libsrcml_version_string() << '\n';
+
         // output the supported srcML source-code languages
         for (size_t i = 0; i < srcml_get_language_list_size(); ++i) {
             std::cout << "srcml " << srcml_get_language_list(i) << ": " << srcml_markup_version_string(srcml_get_language_list(i)) << '\n';
         }
 
-        std::cout << "srcml client: " << SRCML_CLIENT_VERSION_STRING << '\n'
-                  << "libsrcml: " << srcml_libsrcml_version_string() << '\n';
         return 0;
     }
 

--- a/src/client/srcml.cpp
+++ b/src/client/srcml.cpp
@@ -24,11 +24,14 @@
 #include <TraceLog.hpp>
 #include <stdin_libarchive.hpp>
 #include <input_archive.hpp>
+#include <string_view>
 
 #ifndef _MSC_VER
 #include <sys/uio.h>
 #include <unistd.h>
 #endif
+
+using namespace ::std::literals::string_view_literals;
 
 namespace {
     // decide if a step is needed
@@ -60,9 +63,23 @@ int main(int argc, char* argv[]) {
 
         std::cout << "markup: " << '\n';
 
-        // output the supported srcML source-code languages
+        // output Python support first
         for (size_t i = 0; i < srcml_get_language_list_size(); ++i) {
-            std::cout << "  " << srcml_get_language_list(i) << ": " << srcml_markup_version_string(srcml_get_language_list(i)) << '\n';
+            std::string_view language = srcml_get_language_list(i);
+            if (language != "Python"sv)
+                continue;
+
+            std::cout << "  " << language << ": " << srcml_markup_version_string(srcml_get_language_list(i)) << '\n';
+            break;
+        }
+
+        // output other languages support
+        for (size_t i = 0; i < srcml_get_language_list_size(); ++i) {
+            std::string_view language = srcml_get_language_list(i);
+            if (language == "Python"sv)
+                continue;
+
+            std::cout << "  " << language << ": " << srcml_markup_version_string(srcml_get_language_list(i)) << '\n';
         }
 
         return 0;

--- a/src/client/srcml.cpp
+++ b/src/client/srcml.cpp
@@ -59,7 +59,8 @@ int main(int argc, char* argv[]) {
 
         // output the client and libsrcml versions
         std::cout << "srcml: " << SRCML_CLIENT_VERSION_STRING << '\n'
-                  << "libsrcml: " << srcml_libsrcml_version_string() << '\n';
+                  << "libsrcml: " << srcml_libsrcml_version_string() << '\n'
+                  << "srcql: " << "1.0.0" << '\n';
 
         std::cout << "markup:" << '\n';
 

--- a/src/client/srcml.cpp
+++ b/src/client/srcml.cpp
@@ -55,12 +55,14 @@ int main(int argc, char* argv[]) {
     if (option(SRCML_COMMAND_VERSION)) {
 
         // output the client and libsrcml versions
-        std::cout << "srcml client: " << SRCML_CLIENT_VERSION_STRING << '\n'
+        std::cout << "srcml: " << SRCML_CLIENT_VERSION_STRING << '\n'
                   << "libsrcml: " << srcml_libsrcml_version_string() << '\n';
+
+        std::cout << "markup: " << '\n';
 
         // output the supported srcML source-code languages
         for (size_t i = 0; i < srcml_get_language_list_size(); ++i) {
-            std::cout << "srcml " << srcml_get_language_list(i) << ": " << srcml_markup_version_string(srcml_get_language_list(i)) << '\n';
+            std::cout << "  " << srcml_get_language_list(i) << ": " << srcml_markup_version_string(srcml_get_language_list(i)) << '\n';
         }
 
         return 0;

--- a/src/libsrcml/CMakeLists.txt
+++ b/src/libsrcml/CMakeLists.txt
@@ -40,7 +40,15 @@ set(LIBSRCML_OBJECTS $<TARGET_OBJECTS:libsrcml> $<TARGET_OBJECTS:parser> $<TARGE
 if(NOT MSVC)
     set(LIBSRCML_OBJECT_FILENAME libsrcml${CMAKE_CXX_OUTPUT_EXTENSION})
 
-    if(NOT "${CMAKE_OSX_ARCHITECTURES}" STREQUAL "")
+   if(${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+        # Use emcc to combine wasm32 objects
+        add_custom_command(
+            OUTPUT ${LIBSRCML_OBJECT_FILENAME}
+            COMMAND emcc -r ${LIBSRCML_OBJECTS} -o ${LIBSRCML_OBJECT_FILENAME}
+            DEPENDS libsrcml parser antlr
+            COMMAND_EXPAND_LISTS
+        )
+    elsif(NOT "${CMAKE_OSX_ARCHITECTURES}" STREQUAL "")
         # Generate a single-object library for both architectures, then combine them into one
         add_custom_command(
           OUTPUT ${LIBSRCML_OBJECT_FILENAME}

--- a/src/libsrcml/srcml.h
+++ b/src/libsrcml/srcml.h
@@ -68,7 +68,7 @@ typedef SSIZE_T ssize_t;
 /** Number representing libsrcml version */
 #define SRCML_LIBSRCML_VERSION_NUMBER 100000
 /** String containing libsrcml version */
-#define SRCML_LIBSRCML_VERSION_STRING "1.0.0"
+#define SRCML_LIBSRCML_VERSION_STRING "1.1.0"
 /**@}*/
 
 /**@{ @name Status */

--- a/test/client/testsuite/CMakeLists.txt
+++ b/test/client/testsuite/CMakeLists.txt
@@ -18,6 +18,4 @@ foreach(CLIENT_TEST IN ITEMS ${CLIENT_TESTS})
     #set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 10)
 
     set_tests_properties(srcml.${TEST_NAME} PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-
-    message(STATUS "Adding test: ${CLIENT_TEST}")
 endforeach()

--- a/test/client/testsuite/version.sh
+++ b/test/client/testsuite/version.sh
@@ -10,14 +10,14 @@ source $(dirname "$0")/framework_test.sh
 
 # test
 define output <<- 'STDOUT'
+	srcml client: 1.1.0
+	libsrcml: 1.1.0
 	srcml C: 1.0.0
 	srcml C++: 1.0.0
 	srcml C#: 1.0.0
 	srcml Java: 1.0.0
 	srcml Python: 1.0.0
 	srcml Objective-C: 1.0.0
-	srcml client: 1.0.0
-	libsrcml: 1.0.0
 STDOUT
 
 srcml -V

--- a/test/client/testsuite/version.sh
+++ b/test/client/testsuite/version.sh
@@ -12,6 +12,7 @@ source $(dirname "$0")/framework_test.sh
 define output <<- 'STDOUT'
 	srcml: 1.1.0
 	libsrcml: 1.1.0
+	srcql: 1.0.0
 	markup:
 	  Python: 1.0.0
 	  C: 1.0.0

--- a/test/client/testsuite/version.sh
+++ b/test/client/testsuite/version.sh
@@ -10,14 +10,15 @@ source $(dirname "$0")/framework_test.sh
 
 # test
 define output <<- 'STDOUT'
-	srcml client: 1.1.0
+	srcml: 1.1.0
 	libsrcml: 1.1.0
-	srcml C: 1.0.0
-	srcml C++: 1.0.0
-	srcml C#: 1.0.0
-	srcml Java: 1.0.0
-	srcml Python: 1.0.0
-	srcml Objective-C: 1.0.0
+	markup:
+	  Python: 1.0.0
+	  C: 1.0.0
+	  C++: 1.0.0
+	  C#: 1.0.0
+	  Java: 1.0.0
+	  Objective-C: 1.0.0
 STDOUT
 
 srcml -V


### PR DESCRIPTION
- **Change back to v1.1.0**
- **Change back to v1.1.0**
- **Fix using wrong linker on WASM**
- **Switch the order of version output so srcml and libsrcml are first**
- **Switch new commits to 1.1.0**
- **Remove debug for CPACK_PACKAGE_NAME**
- **Rearrange version information**
- **Ouput Python first**
- **Remove extra space at eol**
- **Fix test case for new --version format**
- **Add to authors on the manpage**
- **Set correct client version for documentation**
- **Remove client test debugging stagement**
- **Remove comments from presets (sigh)**
- **Fix name changes in bake comments and collective targets**
- **Change from repeated stages to context and depends-on**
- **Uncomment description (now accepted at depot.dev)**
- **Add CHANGES file**
- **Add individual architecture packages for macOS**
- **Correct configure and build commands when switching architectures**
- **Add clean step**
- **Remove build directory before rebuilding**
- **Separately upload macOS packages**
- **Split macOS packaging into separate jobs and log tests**
- **Generalize installed package name**
- **Move testing, logging, and upload to separate actions**
- **Return to all architectures**
- **Add verbose to ctests**
- **Fix path**
- **Change to standard subdirectory for build**
- **Change to only use one architecture to save minutes**
- **Fix location of build on another command**
- **Fix overriding the build directory**
- **Fix path to macOS package**
- **Fix path for installer upload**
- **Fix prefix**
- **Fix names of artifacts for macOS**
- **Turn on all macOS packages**
- **Rename artifacts in Windows to changes in macOS**
- **Add new API to CHANGES.md**
- **Fix wrong name for installers packages**
- **Add debugging for vcpkg**
- **Add back in the  missing caching using a new scheme**
- **Restore BuildWindows action, and put the cache changes into the separate vcpkg action**
- **Add version for srcql**
