### PR TITLE
Fix nullptr string init from libxml2 error handling

### DIFF
--- a/src/libsrcml/srcSAXController.cpp
+++ b/src/libsrcml/srcSAXController.cpp
@@ -70,7 +70,11 @@ void srcSAXController::parse(srcSAXHandler * handler) {
     if (status != 0) {
 
         auto ep = xmlCtxtGetLastError(context->libxml2_context);
-        SAXError error = { std::string(ep->message), ep->code };
+        std::string error_message = "Unknown error message from libxml2 - code: " + ep->code;
+        if (ep->message) {
+            error_message = ep->message;
+        }
+        SAXError error = { error_message, ep->code };
 
         throw error;
     }

--- a/src/libsrcml/srcml_sax2_reader.cpp
+++ b/src/libsrcml/srcml_sax2_reader.cpp
@@ -23,7 +23,7 @@ static void* start_routine(thread_args* args) {
 
     } catch(SAXError error) {
 
-        if (!(error.error_code == XML_ERR_EXTRA_CONTENT || error.error_code == XML_ERR_DOCUMENT_END)) {
+        if (!(error.error_code == XML_ERR_EXTRA_CONTENT || error.error_code == XML_ERR_DOCUMENT_END || error.error_code == XML_ERR_USER_STOP)) {
 
             fprintf(stderr, "Error Parsing: %s\n", error.message.data());
 


### PR DESCRIPTION
https://github.com/srcML/srcML/issues/2296 for context, libxml2 is setting an error code when stopping the parser, but does not initialize the error message. 

When there is a valid error message we'll use that, otherwise we'll just spit out a string with the direct error code.