### PR TITLE
Fix potential uses of uninitialized optionals, srcdiff error unused value

### DIFF
--- a/src/client/src_input_file.cpp
+++ b/src/client/src_input_file.cpp
@@ -38,7 +38,7 @@ int src_input_file(ParseQueue& queue,
     prequest->srcml_arch = srcml_arch;
     prequest->language = srcml_request.att_language ? *srcml_request.att_language : "";
 
-    if (prequest->language.empty())
+    if (prequest->language.empty() && prequest->filename)
         if (const char* l = srcml_archive_check_extension(srcml_arch, prequest->filename->c_str()))
             prequest->language = l;
 

--- a/src/client/src_input_text.cpp
+++ b/src/client/src_input_text.cpp
@@ -64,8 +64,8 @@ int src_input_text(ParseQueue& queue,
         prequest->srcml_arch = srcml_arch;
         prequest->language = srcml_request.att_language ? *srcml_request.att_language : "";
 
-        // if there there is no language specified, then try to use the filename extension
-        if (prequest->language.empty())
+        // if there is no language specified, then try to use the filename extension
+        if (prequest->language.empty() && prequest->filename)
             if (const char* l = srcml_archive_check_extension(srcml_arch, prequest->filename->data()))
                 prequest->language = l;
 

--- a/src/client/srcml_input_srcml.cpp
+++ b/src/client/srcml_input_srcml.cpp
@@ -36,9 +36,8 @@ int srcml_input_srcml(ParseQueue& queue,
 
     int open_status = SRCML_STATUS_OK;
     if (revision)
-        // VALUE_NEVER_USED
         open_status = srcml_archive_set_srcdiff_revision(srcml_input_archive.get(), *revision);
-    open_status = srcml_archive_read_open(srcml_input_archive.get(), srcml_input);
+    open_status |= srcml_archive_read_open(srcml_input_archive.get(), srcml_input);
 
     if (open_status != SRCML_STATUS_OK) {
         if (srcml_input.protocol == "file"sv)

--- a/src/client/srcml_input_srcml.cpp
+++ b/src/client/srcml_input_srcml.cpp
@@ -36,6 +36,7 @@ int srcml_input_srcml(ParseQueue& queue,
 
     int open_status = SRCML_STATUS_OK;
     if (revision)
+        // VALUE_NEVER_USED
         open_status = srcml_archive_set_srcdiff_revision(srcml_input_archive.get(), *revision);
     open_status = srcml_archive_read_open(srcml_input_archive.get(), srcml_input);
 

--- a/src/libsrcml/srcml_unit.cpp
+++ b/src/libsrcml/srcml_unit.cpp
@@ -64,9 +64,8 @@ int srcml_unit_set_language(struct srcml_unit* unit, const char* language) {
         unit->language = language;
     else
         unit->language = decltype(unit->language)();
-
     // revision is based on language
-    unit->revision = srcml_markup_version_string(unit->language->data());
+    unit->revision = srcml_markup_version_string(unit->language.value_or("").c_str());
 
     return SRCML_STATUS_OK;
 }


### PR DESCRIPTION
Added a couple pre checks to some optional usages, and for the set language nullptr issue in #2296, added a default of an empty string.

Also noticed an unused value for some srcdiff logic, patching it for now but don't think that logic belongs there long term.