### PR TITLE
Add Ubuntu 25.10, 26.04 and Fedora 44; devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+// For more customization options, see https://containers.dev/implementors/json_reference
+{
+  "name": "srcml-dev",
+  "image": "srcml/ubuntu:latest",
+  "features": {
+    "ghcr.io/devcontainers/features/git" : {}
+    // Add additional features to your project using auto-completion.
+  }
+}

--- a/compose.yml
+++ b/compose.yml
@@ -21,10 +21,26 @@ x-utilities: &UTILITIES
 
 services:
 
+  ubuntu_26_04:
+    image: srcml/ubuntu:26.04
+    platform: ${PLATFORM}
+    profiles: [ubuntu, package, latest]
+    environment:
+      - WORKFLOW=ubuntu
+    <<: *CONFIGURATION
+
+  ubuntu_25_10:
+    image: srcml/ubuntu:25.10
+    platform: ${PLATFORM}
+    profiles: [ubuntu, package]
+    environment:
+      - WORKFLOW=ubuntu
+    <<: *CONFIGURATION
+
   ubuntu_25_04:
     image: srcml/ubuntu:25.04
     platform: ${PLATFORM}
-    profiles: [ubuntu, package, latest]
+    profiles: [ubuntu, package]
     environment:
       - WORKFLOW=ubuntu
     <<: *CONFIGURATION
@@ -61,10 +77,18 @@ services:
       - WORKFLOW=ubuntu
     <<: *CONFIGURATION
 
+  fedora_44:
+    image: srcml/fedora:44
+    platform: ${PLATFORM}
+    profiles: [fedora, package, latest]
+    environment:
+      - WORKFLOW=rpm
+    <<: *CONFIGURATION
+
   fedora_43:
     image: srcml/fedora:43
     platform: ${PLATFORM}
-    profiles: [fedora, package, latest]
+    profiles: [fedora, package]
     environment:
       - WORKFLOW=rpm
     <<: *CONFIGURATION

--- a/docker-bake.override.hcl
+++ b/docker-bake.override.hcl
@@ -23,12 +23,15 @@
 variable "distributions" {
   description = "Table of supported Linux distributions"
   default = [
-    { id = "ubuntu",   version_id = "25.04",  java_version_id="22.04", name = "Ubuntu 25.04", workflow = "ubuntu", java = "latest", tag = "latest" },
-    { id = "ubuntu",   version_id = "24.10",  java_version_id="22.04", name = "Ubuntu 24.10", workflow = "ubuntu", java = "latest"},
-    { id = "ubuntu",   version_id = "24.04",  java_version_id="22.04", name = "Ubuntu 24.04", workflow = "ubuntu", java = "latest"},
+    { id = "ubuntu",   version_id = "26.04",  java_version_id="22.04", name = "Ubuntu 26.04", workflow = "ubuntu", java = "latest", tag = "latest" },
+    { id = "ubuntu",   version_id = "25.10",  java_version_id="22.04", name = "Ubuntu 25.10", workflow = "ubuntu", java = "latest" },
+    { id = "ubuntu",   version_id = "25.04",  java_version_id="22.04", name = "Ubuntu 25.04", workflow = "ubuntu", java = "latest" },
+    { id = "ubuntu",   version_id = "24.10",  java_version_id="22.04", name = "Ubuntu 24.10", workflow = "ubuntu", java = "latest" },
+    { id = "ubuntu",   version_id = "24.04",  java_version_id="22.04", name = "Ubuntu 24.04", workflow = "ubuntu", java = "latest" },
     { id = "ubuntu",   version_id = "22.04",  java_version_id="22.04", name = "Ubuntu 22.04", workflow = "ubuntu" },
     { id = "ubuntu",   version_id = "20.04",  java_version_id="20.04", name = "Ubuntu 20.04", workflow = "ubuntu", cmake = "ON", tag = "earliest" },
-    { id = "fedora",   version_id = "43",     java_version_id="38",    name = "Fedora 43", workflow = "rpm",    java = "latest", tag = "latest" },
+    { id = "fedora",   version_id = "44",     java_version_id="38",    name = "Fedora 44", workflow = "rpm",    java = "latest", tag = "latest" },
+    { id = "fedora",   version_id = "43",     java_version_id="38",    name = "Fedora 43", workflow = "rpm",    java = "latest" },
     { id = "fedora",   version_id = "42",     java_version_id="38",    name = "Fedora 42", workflow = "rpm",    java = "latest" },
     { id = "fedora",   version_id = "41",     java_version_id="38",    name = "Fedora 41", workflow = "rpm",    java = "17" },
     { id = "fedora",   version_id = "40",     java_version_id="38",    name = "Fedora 40", workflow = "rpm",    java = "17" },


### PR DESCRIPTION
All tests pass with #2297 and #2299 merged in.

Also adds a devcontainer.json file to enable the use of a dev container for development.