### PR TITLE
Update circleci config, output junit from ctest for client and libsrcml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,28 @@
 version: 2
 jobs:
-    build:
-      branches:
-        only:
-          - develop
+    build_ubuntu:
       docker:
-        - image: srcml/ubuntu:24.04
+        - image: srcml/ubuntu:latest
       steps:
+        - run: apt-get update
+        - run: apt-get install -y ssh
         - checkout
         - run: cmake --workflow --preset ci-ubuntu
+        - store_test_results:
+            path: /root/project-build/dist/
+
+    build_fedora:
+      docker:
+        - image: srcml/fedora:latest
+      steps:
+        - checkout
+        - run: cmake --workflow --preset ci-rpm
+        - store_test_results:
+            path: /root/project-build/dist/
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build_ubuntu
+      - build_fedora

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -90,16 +90,17 @@ function(add_workflow_test_targets binary_dir output_directory package_file_name
     # Target for test_client
     add_custom_target(test_client
         WORKING_DIRECTORY ${binary_dir}
-        COMMAND ${CMAKE_CTEST_COMMAND} -VV -R ^srcml --timeout ${SRCML_TEST_TIMEOUT} --output-log ${output_directory}/${package_file_name}-client.log || true
+        COMMAND ${CMAKE_CTEST_COMMAND} -VV -R ^srcml --timeout ${SRCML_TEST_TIMEOUT} --output-log ${output_directory}/${package_file_name}-client.log --output-junit ${output_directory}/${package_file_name}-client.xml || true
     )
 
     # Target for test_libsrcml
     add_custom_target(test_libsrcml
         WORKING_DIRECTORY ${binary_dir}
-        COMMAND ${CMAKE_CTEST_COMMAND} -VV -R ^libsrcml --timeout ${SRCML_TEST_TIMEOUT} --output-log ${output_directory}/${package_file_name}-libsrcml.log || true
+        COMMAND ${CMAKE_CTEST_COMMAND} -VV -R ^libsrcml --timeout ${SRCML_TEST_TIMEOUT} --output-log ${output_directory}/${package_file_name}-libsrcml.log --output-junit ${output_directory}/${package_file_name}-libsrcml.xml || true
     )
 
     # Target for test_parser
+    # TODO: export/convert log to junit for ingestion into circleci
     add_custom_target(test_parser
         WORKING_DIRECTORY ${binary_dir}
         COMMAND ${CMAKE_COMMAND} --build . --target run_parser_tests | tee ${output_directory}/${package_file_name}-parser.log


### PR DESCRIPTION
Updated circleci to build based on the following

`
PR opened or pushed to, default branch and tag pushes: Trigger a pipeline on pushes to a branch for which there is an open Pull Request (PR), when a PR is opened, pushes to any tag, and pushes to the default branch. This applies also if the PR is re-opened after being closed.
`

TLDR; adds circleci builds for PRs and tags onto the existing `develop` branch pushes.

Added fedora testing, so now both ubuntu and fedora latest will automatically be built and tested.

Added junit output for the client and libsrcml to enable easier viewing of failed tests in circleci. parser tests don't use the typical ctest, so we won't have those easily viewable currently.