### PR TITLE
Add cmake build option to disable remote client tests

### DIFF
--- a/test/client/testsuite/CMakeLists.txt
+++ b/test/client/testsuite/CMakeLists.txt
@@ -6,9 +6,12 @@
 # 
 # CMake files for client tests
 
+option(RUN_REMOTE_CLIENT_TESTS "Build remote client tests" ON)
+
 # add client tests
-file(GLOB CLIENT_TESTS "${CMAKE_CURRENT_SOURCE_DIR}/*.sh")
-list(REMOVE_ITEM CLIENT_TESTS "${CMAKE_CURRENT_SOURCE_DIR}/framework_test.sh")
+file(GLOB REMOTE_CLIENT_TESTS "${CMAKE_CURRENT_SOURCE_DIR}/remote*.sh")
+file(GLOB LOCAL_CLIENT_TESTS "${CMAKE_CURRENT_SOURCE_DIR}/*.sh")
+list(FILTER LOCAL_CLIENT_TESTS EXCLUDE REGEX "/remote_|framework_test.sh")
 
 # use Git Bash to run tests on Windows
 set(BASH bash)
@@ -24,12 +27,24 @@ if (WIN32)
     endif()
 endif()
 
-foreach(CLIENT_TEST IN ITEMS ${CLIENT_TESTS})
-    get_filename_component(TEST_NAME ${CLIENT_TEST} NAME)
+foreach(LOCAL_CLIENT_TEST IN ITEMS ${LOCAL_CLIENT_TESTS})
+    get_filename_component(TEST_NAME ${LOCAL_CLIENT_TEST} NAME)
 
-    add_test(NAME srcml.${TEST_NAME} COMMAND ${BASH} ${CLIENT_TEST})
+    add_test(NAME srcml.${TEST_NAME} COMMAND ${BASH} ${LOCAL_CLIENT_TEST})
     # Command line --timeout does NOT override this value
     #set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 10)
 
     set_tests_properties(srcml.${TEST_NAME} PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endforeach()
+
+if(RUN_REMOTE_CLIENT_TESTS)
+    foreach(REMOTE_CLIENT_TEST IN ITEMS ${REMOTE_CLIENT_TESTS})
+        get_filename_component(TEST_NAME ${REMOTE_CLIENT_TEST} NAME)
+
+        add_test(NAME srcml.${TEST_NAME} COMMAND ${BASH} ${REMOTE_CLIENT_TEST})
+        # Command line --timeout does NOT override this value
+        #set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 10)
+
+        set_tests_properties(srcml.${TEST_NAME} PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    endforeach()
+endif()


### PR DESCRIPTION
Adding a cmake option so we can toggle remote tests off if desired (no internet, or want to reduce test time by around a minute while working iteratively) 