### PR TITLE
Rework windows build workflows

### DIFF
--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -1,7 +1,7 @@
-name: Setup vcpkg with cache
+name: Setup vcpkg
 
 description: |
-  Checks out vcpkg, bootstraps it, and sets up binary cache with optional R2 remote cache.
+  Sets up vcpkg with nuget binary caching.
 
 inputs:
   vcpkg-ref:
@@ -12,74 +12,78 @@ inputs:
     description: 'vcpkg triplet (used only for cache partitioning)'
     required: false
     default: 'x64-windows'
-  r2-access-key:
-    description: 'Cloudflare R2 access key (optional - enables remote cache)'
+  github-token:
+    description: 'GitHub token used for authenticating to GitHub Packages NuGet feed'
+    required: true
+  no-remote-cache:
+    description: 'Whether to disable remote cache (nuget) and only use local cache'
     required: false
-    default: ''
-  r2-secret-key:
-    description: 'Cloudflare R2 secret key (optional - enables remote cache)'
+    default: false
+  feed-url:
+    description: 'The URL of the NuGet feed to use for vcpkg binary caching'
     required: false
-    default: ''
-  r2-bucket:
-    description: 'R2 bucket name for vcpkg cache (optional)'
+    default: 'https://nuget.pkg.github.com/srcML/index.json'
+  username:
+    description: 'The username to authenticate to the NuGet feed'
     required: false
-    default: ''
-  r2-endpoint:
-    description: 'R2 endpoint URL (optional)'
-    required: false
-    default: ''
+    default: 'srcML'
 
 runs:
   using: "composite"
   steps:
-    - name: Set vcpkg cache env
+    - name: Set vcpkg env
       shell: bash
       run: |
-        echo "VCPKG_FEATURE_FLAGS=manifests,binarycaching" >> "$GITHUB_ENV"
-        echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg-cache" >> "$GITHUB_ENV"
-        echo "VCPKG_DEFAULT_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
-        echo "VCPKG_DEFAULT_HOST_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
+        echo "VCPKG_BINARY_SOURCES=clear;nuget,${{ inputs.feed-url }},readwrite" >> "$GITHUB_ENV"
         echo "VCPKG_BUILD_TYPE=release" >> "$GITHUB_ENV"
+        echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg-cache" >> "$GITHUB_ENV"
+        echo "VCPKG_DEFAULT_HOST_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
+        echo "VCPKG_DEFAULT_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
         mkdir -p "$GITHUB_WORKSPACE/vcpkg-cache"
 
-        # Configure binary sources based on whether R2 credentials are provided
-        if [ -n "${{ inputs.r2-access-key }}" ] && [ -n "${{ inputs.r2-secret-key }}" ]; then
-          echo "Setting up R2 remote cache + local fallback"
-          echo "VCPKG_BINARY_SOURCES=clear;x-aws,s3://${{ inputs.r2-bucket }}/vcpkg-cache,readwrite;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
-          echo "AWS_ACCESS_KEY_ID=${{ inputs.r2-access-key }}" >> "$GITHUB_ENV"
-          echo "AWS_SECRET_ACCESS_KEY=${{ inputs.r2-secret-key }}" >> "$GITHUB_ENV"
-          echo "AWS_DEFAULT_REGION=auto" >> "$GITHUB_ENV"
-          echo "AWS_ENDPOINT_URL=${{ inputs.r2-endpoint }}" >> "$GITHUB_ENV"
-        else
-          echo "Using local cache only"
+        if [ "${{ inputs.no-remote-cache }}" = "true" ]; then
+          echo "Remote cache disabled, using local cache at $GITHUB_WORKSPACE/vcpkg-cache"
           echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
         fi
 
-    - name: Debug vcpkg env
-      shell: bash
-      run: |
-        echo "VCPKG_BINARY_SOURCES=$VCPKG_BINARY_SOURCES"
-        echo "AWS_ENDPOINT_URL=$AWS_ENDPOINT_URL"
-        echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
-
-    - name: Cache vcpkg binary artifacts
-      uses: actions/cache@v4
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11
+      id: runvcpkg
       with:
-        path: ${{ env.VCPKG_CACHE_DIR }}
-        key: vcpkg-bin-release-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
-        restore-keys: |
-          vcpkg-bin-release-v1-${{ runner.os }}-${{ inputs.triplet }}-
-          vcpkg-bin-release-v1-${{ runner.os }}-
+        vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
+        vcpkgGitCommitId: '${{ inputs.vcpkg-ref}}'
+        vcpkgJsonGlob: '**/vcpkg.json'
 
-    - name: Clone vcpkg
+    - name: Prints output of run-vcpkg's action
       shell: bash
-      run: |
-        git config --global advice.detachedHead false
-        git clone https://github.com/microsoft/vcpkg.git
-        cd vcpkg
-        git checkout --quiet ${{ inputs.vcpkg-ref }}
+      run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}'"
 
-    - name: Bootstrap vcpkg
-      shell: bash
+    - name: Add NuGet sources on Windows
+      shell: pwsh
+      if: ${{ inputs.triplet == 'x64-windows' }}
       run: |
-        ./vcpkg/bootstrap-vcpkg.sh
+        .$(vcpkg fetch nuget) `
+          sources add `
+          -Source "${{ inputs.feed-url }}" `
+          -StorePasswordInClearText `
+          -Name GitHubPackages `
+          -UserName "${{ inputs.username }}" `
+          -Password "${{ inputs.github-token }}"
+        .$(vcpkg fetch nuget) `
+          setapikey "${{ inputs.github-token }}" `
+          -Source "${{ inputs.feed-url }}"
+
+    # TODO: Handle mono install here for non-Windows platforms
+
+    - name: Add NuGet sources on non-Windows platforms
+      shell: bash
+      if: ${{ inputs.triplet != 'x64-windows' }}
+      run: |
+        mono `vcpkg fetch nuget | tail -n 1` sources add \
+          -Source ${{ inputs.feed-url }} \
+          -StorePasswordInClearText \
+          -Name GitHubPackages \
+          -UserName "${{ inputs.username }}" \
+          -Password "${{ inputs.github-token }}"
+        mono `vcpkg fetch nuget | tail -n 1` setapikey ${{ inputs.github-token }} \
+          -Source ${{ inputs.feed-url }}

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -3,58 +3,39 @@ name: Build Windows
 
 on: workflow_dispatch
 
+permissions:
+  packages: write
+
 jobs:
-  build:
-    runs-on: windows-latest
-    timeout-minutes: 30
+  job:
+    name: ${{ matrix.os }}-${{ github.workflow }}
+    runs-on: ${{ matrix.os }}
     environment: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+
     steps:
+      - uses: actions/checkout@v4
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Setup Windows
-        uses: microsoft/setup-msbuild@v1.3.1
+      - uses: lukka/get-cmake@latest
 
       - name: Setup vcpkg
         uses: ./.github/actions/vcpkg
         with:
-          vcpkg-ref: e140b1fde236eb682b0d47f905e65008a191800f
-          r2-access-key: ${{ secrets.R2_ACCESS_KEY }}
-          r2-secret-key: ${{ secrets.R2_SECRET_KEY }}
-          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
-          r2-endpoint: ${{ secrets.R2_ENDPOINT }}
-
-      - name: Set up CMake
-        uses: lukka/get-cmake@latest
-        with:
-          cmakeVersion: 4.0
-
-      - name: Setup devcmd to use cl.exe
-        uses: ilammy/msvc-dev-cmd@v1.13.0
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create build directory
         shell: bash
-        run: |
-          cmake --version
-          mkdir build
+        run: mkdir build
 
-      - name: CMake Setup on Windows
-        shell: bash
-        working-directory: build
-        run: |
-          export UseMultiToolTask=true
-          cmake .. --preset ci-msvc
+      - name: Run CMake with vcpkg.json manifest
+        uses: lukka/run-cmake@v10
+        with:
+          workflowPreset: ci-msvc
 
-      - name: Build
-        shell: bash
-        working-directory: build
-        continue-on-error: true
-        run: |
-          export UseMultiToolTask=true
-          cmake --build . --config Release
-
-      - name: Package
+      - name: List packages
         working-directory: build
         continue-on-error: true
         run: |
@@ -77,191 +58,3 @@ jobs:
             build/dist/*.zip
             build/dist/*.exe
             build/dist/*.nupkg
-
-      - name: Install from build
-        working-directory: build
-        continue-on-error: true
-        run: |
-          cmake --build . --config Release --target install
-
-      - name: Set PATH for Windows
-        shell: bash
-        continue-on-error: true
-        run: |
-          echo "/c/Program Files/srcML/bin" >> $GITHUB_PATH
-
-      - name: Run Installed srcml
-        shell: bash
-        working-directory: build
-        continue-on-error: true
-        run: |
-          EOL="\r\n"
-          SRCML_HOME="/c/Program Files/srcML/bin"
-          ls -lh "$SRCML_HOME"
-          SRCML="$SRCML_HOME/srcml.exe"
-          ls -lh "$SRCML"
-          export MSYS2_ARG_CONV_EXCL="*"
-          diff='diff -Z '
-          "$SRCML" --version
-          "$SRCML" --text="int a;" -l C++
-          touch "a.cpp"
-          "$SRCML" a.cpp
-          echo "a;" >> a.cpp
-          "$SRCML" a.cpp
-          echo "b;" >> b.cpp
-          "$SRCML" a.cpp b.cpp
-
-      - name: Create build examples directory
-        shell: bash
-        continue-on-error: true
-        run: |
-          mkdir build2
-
-      - name: Build examples
-        shell: bash
-        working-directory: build2
-        continue-on-error: true
-        run: |
-          cmake "/c/Program Files/srcML/share/srcml/examples/libsrcml" -DsrcML_DIR="C:/Program Files/srcML/cmake" -G Ninja
-          ninja
-
-      - name: Run examples in PowerShell (see loader errors)
-        shell: pwsh
-        working-directory: build2
-        continue-on-error: true
-        run: |
-          Get-ChildItem *.exe
-          foreach ($e in Get-ChildItem *.exe) {
-            Write-Host "== $($e.Name) =="
-            & .\${e.Name}
-            if ($LASTEXITCODE) { Write-Host "rc=$LASTEXITCODE" }
-          }
-
-      - name: Run examples
-        shell: bash
-        working-directory: build2
-        continue-on-error: true
-        run: |
-          ls *.exe
-          ./srcml_copy_archive.exe || echo $?
-          ./srcml_create_archive_fd.exe || echo $?
-          ./srcml_create_archive_file.exe || echo $?
-          ./srcml_create_archive_filename.exe || echo $?
-          ./srcml_create_archive_full.exe || echo $?
-          ./srcml_direct_language.exe || echo $?
-          ./srcml_direct_language_list.exe || echo $?
-          ./srcml_direct_language_xml.exe || echo $?
-          ./srcml_direct_src2srcml.exe || echo $?
-          ./srcml_direct_srcml2src.exe || echo $?
-          ./srcml_list.exe || echo $?
-          ./srcml_read_archive_fd.exe || echo $?
-          ./srcml_read_archive_file.exe || echo $?
-          ./srcml_read_archive_filename.exe || echo $?
-          ./srcml_read_archive_full.exe || echo $?
-          ./srcml_read_archive_memory.exe || echo $?
-          ./srcml_relaxng.exe || echo $?
-          ./srcml_sort_archive.exe || echo $?
-          ./srcml_split_archive.exe || echo $?
-          ./srcml_transform.exe || echo $?
-          ./srcml_xpath.exe || echo $?
-          ./srcml_xslt.exe || echo $?
-
-  test-installer:
-    needs: build
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        installer: [msi, inno, nuget]
-
-    steps:
-
-      # Download the installer artifact
-      - name: Download installer
-        uses: actions/download-artifact@v4
-        with:
-          name: "Windows Packages"
-
-      - name: Install package Wix msi
-        if: ${{ matrix.installer == 'msi' }}
-        run: |
-          msiexec /i srcml-1.1.0-windows-x86_64.msi /quiet /norestart /L*vx .\msi.log
-      - uses: actions/upload-artifact@v4
-        with:
-          name: msi.windows-latest.log
-          path: msi.log
-
-      - name: Install package Inno Setup
-        if: ${{ matrix.installer == 'inno' }}
-        run: |
-          dir
-          D:\a\srcML\srcML\srcml-1.1.0-windows-x86_64.exe /VERYSILENT /LOG="$GITHUB_WORKSPACE/inno.log"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: inno.windows-latest.log
-          path: inno.log
-
-      - name: Install package Nuget
-        if: ${{ matrix.installer == 'nuget' }}
-        run: |
-          mkdir LocalNuGetFeed
-          nuget add srcml.1.1.0.nupkg -Source LocalNuGetFeed -Verbosity detailed -NonInteractive
-          nuget install srcml -Source D:\a\srcML\srcML\LocalNuGetFeed -OutputDirectory "C:\Program Files" -Verbosity detailed -NonInteractive
-          mv "C:\Program Files\srcml.1.1.0" "C:\Program Files\srcML"
-
-      - name: Set PATH for Windows
-        shell: bash
-        continue-on-error: true
-        run: |
-          echo "C:\\Program Files\\srcML\\bin" >> "$GITHUB_PATH"
-          ls -lh "/c/Program Files/srcML/bin"
-
-      - name: Run Installed srcml
-        shell: bash
-        continue-on-error: true
-        run: |
-          srcml --help
-          srcml --text="a;" -l C++
-
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Setup msys2 with additional client-test packages for Windows
-        uses: msys2/setup-msys2@v2
-        continue-on-error: true
-        with:
-          install: >-
-            zip
-            cpio
-            diffutils
-            util-linux
-            cmake
-            libxml2
-
-      - name: Create build directory
-        shell: bash
-        run: |
-          mkdir build
-
-      - name: Build
-        shell: bash
-        working-directory: build
-        continue-on-error: true
-        run: |
-          export UseMultiToolTask=true
-          cmake ../test -DSRCML_TEST_INSTALLED=ON -G Ninja
-
-      - name: Test client
-        uses: ./.github/actions/test-client
-        with:
-          prefix: "Windows ${{ matrix.installer }}"
-
-      - name: Test libsrcml
-        uses: ./.github/actions/test-libsrcml
-        with:
-          prefix: "Windows ${{ matrix.installer }}"
-
-      - name: Test parser
-        uses: ./.github/actions/test-parser
-        with:
-          prefix: "Windows ${{ matrix.installer }}"

--- a/.github/workflows/CacheWindowsDependencies.yml
+++ b/.github/workflows/CacheWindowsDependencies.yml
@@ -6,45 +6,31 @@ on:
   schedule:
     - cron: '43 12 * * *'
 
+permissions:
+  packages: write
+
 jobs:
-  build:
-    runs-on: windows-latest
-    timeout-minutes: 30
+  job:
+    name: ${{ matrix.os }}-${{ github.workflow }}
+    runs-on: ${{ matrix.os }}
     environment: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        triplet: [x64-windows]
+
     steps:
+      - uses: actions/checkout@v4
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Setup Windows
-        uses: microsoft/setup-msbuild@v1.3.1
+      - uses: lukka/get-cmake@latest
 
       - name: Setup vcpkg
         uses: ./.github/actions/vcpkg
         with:
-          vcpkg-ref: e140b1fde236eb682b0d47f905e65008a191800f
-          r2-access-key: ${{ secrets.R2_ACCESS_KEY }}
-          r2-secret-key: ${{ secrets.R2_SECRET_KEY }}
-          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
-          r2-endpoint: ${{ secrets.R2_ENDPOINT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up CMake
-        uses: lukka/get-cmake@latest
+      - name: Run CMake
+        uses: lukka/run-cmake@v10
         with:
-          cmakeVersion: 4.0
-
-      - name: Setup devcmd to use cl.exe
-        uses: ilammy/msvc-dev-cmd@v1.13.0
-
-      - name: Create build directory
-        shell: bash
-        run: |
-          cmake --version
-          mkdir build
-
-      - name: CMake Setup on Windows
-        shell: bash
-        working-directory: build
-        run: |
-          export UseMultiToolTask=true
-          cmake .. --preset ci-msvc
+          configurePreset: ci-msvc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@
 # The master CMake project file for srcML
 
 if(DEFINED ENV{VCPKG_ROOT} OR DEFINED CMAKE_TOOLCHAIN_FILE)
+    message(STATUS "Building with vcpkg")
     set(VCPKG_BUILD_TYPE "release")
+    include("$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
 endif()
 
 cmake_minimum_required(VERSION 3.28)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # 
 # The master CMake project file for srcML
 
-if(DEFINED ENV{VCPKG_ROOT} OR DEFINED CMAKE_TOOLCHAIN_FILE)
+if(DEFINED ENV{VCPKG_ROOT})
     message(STATUS "Building with vcpkg")
     set(VCPKG_BUILD_TYPE "release")
     include("$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")

--- a/presets/CMakeMSVCPresets.json
+++ b/presets/CMakeMSVCPresets.json
@@ -10,6 +10,7 @@
       "description": "Default build options for MSVC",
       "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" },
       "toolchainFile": "toolchain-msvc.cmake",
+      "inherits": ["ci-base", "ci-subdirectory-build"],
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "cl",
         "CMAKE_C_COMPILER": "cl",
@@ -22,15 +23,17 @@
         "SRCML_LIBSRCML_SHARED_LINK_FLAGS_RELEASE": "/DEBUG /OPT:REF /OPT:ICF",
         "SRCML_LIBSRCML_STATIC_LINK_FLAGS_RELEASE": "/LTCG:OFF",
         "SRCML_CLIENT_COMPILE_FLAGS": "/wd4355;/wd5204",
-        "SRCML_CLIENT_LINK_FLAGS": ""
+        "SRCML_CLIENT_LINK_FLAGS": "",
+        "VCPKG_FEATURE_FLAGS": "manifests,binarycaching,-compilertracking",
+        "VCPKG_INSTALL_OPTIONS": "--x-abi-tools-use-exact-versions"
       }
     }
   ],
   "buildPresets" : [
     {
       "name": "ci-msvc-only",
-      "displayName": "Ubuntu only",
-      "description": "Restrict to Ubuntu",
+      "displayName": "MSVC only",
+      "description": "Restrict to MSVC",
       "hidden": true,
       "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" },
       "configurePreset": "ci-msvc"


### PR DESCRIPTION
* Reworks vcpkg action to use nuget cache, removing the need to host an S3 compatible bucket elsewhere
* Using lukka/run-vcpkg@v11 for vcpkg install and setup
* Using lukka/run-cmake@v10 for cmake interaction
* Modifies the BuildWindows workflow to use the msvc cmake workflow
* BuildWindows now just builds and uploads build files, controlled by msvc cmake workflow


Primary idea behind these changes are to simplify the setup for building and testing. Testing should be ran as part of the msvc workflow like they are for ubuntu and macos. Future work is to create steps/workflows to test installation on all platforms. 

There are also warnings when building under windows for a variety of things, but will need to tackle those in a separate issue.

