### PR TITLE
Add libsrcml_js target, workflow to build wasm artifacts

### DIFF
--- a/.github/actions/vcpkg/action.yml
+++ b/.github/actions/vcpkg/action.yml
@@ -1,7 +1,7 @@
-name: Setup vcpkg with cache
+name: Setup vcpkg
 
 description: |
-  Checks out vcpkg, bootstraps it, and sets up binary cache with optional R2 remote cache.
+  Sets up vcpkg with nuget binary caching.
 
 inputs:
   vcpkg-ref:
@@ -12,74 +12,78 @@ inputs:
     description: 'vcpkg triplet (used only for cache partitioning)'
     required: false
     default: 'x64-windows'
-  r2-access-key:
-    description: 'Cloudflare R2 access key (optional - enables remote cache)'
+  github-token:
+    description: 'GitHub token used for authenticating to GitHub Packages NuGet feed'
+    required: true
+  no-remote-cache:
+    description: 'Whether to disable remote cache (nuget) and only use local cache'
     required: false
-    default: ''
-  r2-secret-key:
-    description: 'Cloudflare R2 secret key (optional - enables remote cache)'
+    default: false
+  feed-url:
+    description: 'The URL of the NuGet feed to use for vcpkg binary caching'
     required: false
-    default: ''
-  r2-bucket:
-    description: 'R2 bucket name for vcpkg cache (optional)'
+    default: 'https://nuget.pkg.github.com/srcML/index.json'
+  username:
+    description: 'The username to authenticate to the NuGet feed'
     required: false
-    default: ''
-  r2-endpoint:
-    description: 'R2 endpoint URL (optional)'
-    required: false
-    default: ''
+    default: 'srcML'
 
 runs:
   using: "composite"
   steps:
-    - name: Set vcpkg cache env
+    - name: Set vcpkg env
       shell: bash
       run: |
-        echo "VCPKG_FEATURE_FLAGS=manifests,binarycaching" >> "$GITHUB_ENV"
-        echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg-cache" >> "$GITHUB_ENV"
-        echo "VCPKG_DEFAULT_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
-        echo "VCPKG_DEFAULT_HOST_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
+        echo "VCPKG_BINARY_SOURCES=clear;nuget,${{ inputs.feed-url }},readwrite" >> "$GITHUB_ENV"
         echo "VCPKG_BUILD_TYPE=release" >> "$GITHUB_ENV"
+        echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg-cache" >> "$GITHUB_ENV"
+        echo "VCPKG_DEFAULT_HOST_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
+        echo "VCPKG_DEFAULT_TRIPLET=${{ inputs.triplet }}" >> "$GITHUB_ENV"
         mkdir -p "$GITHUB_WORKSPACE/vcpkg-cache"
 
-        # Configure binary sources based on whether R2 credentials are provided
-        if [ -n "${{ inputs.r2-access-key }}" ] && [ -n "${{ inputs.r2-secret-key }}" ]; then
-          echo "Setting up R2 remote cache + local fallback"
-          echo "VCPKG_BINARY_SOURCES=clear;x-aws,s3://${{ inputs.r2-bucket }}/vcpkg-cache,readwrite;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
-          echo "AWS_ACCESS_KEY_ID=${{ inputs.r2-access-key }}" >> "$GITHUB_ENV"
-          echo "AWS_SECRET_ACCESS_KEY=${{ inputs.r2-secret-key }}" >> "$GITHUB_ENV"
-          echo "AWS_DEFAULT_REGION=auto" >> "$GITHUB_ENV"
-          echo "AWS_ENDPOINT_URL=${{ inputs.r2-endpoint }}" >> "$GITHUB_ENV"
-        else
-          echo "Using local cache only"
+        if [ "${{ inputs.no-remote-cache }}" = "true" ]; then
+          echo "Remote cache disabled, using local cache at $GITHUB_WORKSPACE/vcpkg-cache"
           echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg-cache,readwrite" >> "$GITHUB_ENV"
         fi
 
-    - name: Debug vcpkg env
-      shell: bash
-      run: |
-        echo "VCPKG_BINARY_SOURCES=$VCPKG_BINARY_SOURCES"
-        echo "AWS_ENDPOINT_URL=$AWS_ENDPOINT_URL"
-        echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
-
-    - name: Cache vcpkg binary artifacts
-      uses: actions/cache@v4
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11
+      id: runvcpkg
       with:
-        path: ${{ env.VCPKG_CACHE_DIR }}
-        key: vcpkg-bin-release-v1-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
-        restore-keys: |
-          vcpkg-bin-release-v1-${{ runner.os }}-${{ inputs.triplet }}-
-          vcpkg-bin-release-v1-${{ runner.os }}-
+        vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
+        vcpkgGitCommitId: '${{ inputs.vcpkg-ref}}'
+        vcpkgJsonGlob: '**/vcpkg.json'
 
-    - name: Clone vcpkg
+    - name: Prints output of run-vcpkg's action
       shell: bash
-      run: |
-        git config --global advice.detachedHead false
-        git clone https://github.com/microsoft/vcpkg.git
-        cd vcpkg
-        git checkout --quiet ${{ inputs.vcpkg-ref }}
+      run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}'"
 
-    - name: Bootstrap vcpkg
-      shell: bash
+    - name: Add NuGet sources on Windows
+      shell: pwsh
+      if: ${{ inputs.triplet == 'x64-windows' }}
       run: |
-        ./vcpkg/bootstrap-vcpkg.sh
+        .$(vcpkg fetch nuget) `
+          sources add `
+          -Source "${{ inputs.feed-url }}" `
+          -StorePasswordInClearText `
+          -Name GitHubPackages `
+          -UserName "${{ inputs.username }}" `
+          -Password "${{ inputs.github-token }}"
+        .$(vcpkg fetch nuget) `
+          setapikey "${{ inputs.github-token }}" `
+          -Source "${{ inputs.feed-url }}"
+
+    # TODO: Handle mono install here for non-Windows platforms
+
+    - name: Add NuGet sources on non-Windows platforms
+      shell: bash
+      if: ${{ inputs.triplet != 'x64-windows' }}
+      run: |
+        mono `vcpkg fetch nuget | tail -n 1` sources add \
+          -Source ${{ inputs.feed-url }} \
+          -StorePasswordInClearText \
+          -Name GitHubPackages \
+          -UserName "${{ inputs.username }}" \
+          -Password "${{ inputs.github-token }}"
+        mono `vcpkg fetch nuget | tail -n 1` setapikey ${{ inputs.github-token }} \
+          -Source ${{ inputs.feed-url }}

--- a/.github/workflows/BuildWasm.yml
+++ b/.github/workflows/BuildWasm.yml
@@ -9,3 +9,33 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
+      - name: Setup Emscripten SDK
+        uses: mymindstorm/setup-emsdk@v14
+
+      - name: Verify
+        run: emcc -v
+
+      - name: Install Mono
+        run: sudo apt-get install -y mono-complete
+
+      - name: Setup vcpkg
+        uses: ./.github/actions/vcpkg
+        with:
+          triplet: 'wasm32-emscripten'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure
+        run: |
+          emcmake cmake --preset ci-ubuntu-wasm
+
+      - name: Build
+        continue-on-error: true
+        run: |
+          cmake --build build --target libsrcml_js
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "Libsrcml Wasm Artifacts"
+          path: |
+            build/bin/libsrcml*

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -3,58 +3,39 @@ name: Build Windows
 
 on: workflow_dispatch
 
+permissions:
+  packages: write
+
 jobs:
-  build:
-    runs-on: windows-latest
-    timeout-minutes: 30
+  job:
+    name: ${{ matrix.os }}-${{ github.workflow }}
+    runs-on: ${{ matrix.os }}
     environment: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+
     steps:
+      - uses: actions/checkout@v4
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Setup Windows
-        uses: microsoft/setup-msbuild@v1.3.1
+      - uses: lukka/get-cmake@latest
 
       - name: Setup vcpkg
         uses: ./.github/actions/vcpkg
         with:
-          vcpkg-ref: e140b1fde236eb682b0d47f905e65008a191800f
-          r2-access-key: ${{ secrets.R2_ACCESS_KEY }}
-          r2-secret-key: ${{ secrets.R2_SECRET_KEY }}
-          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
-          r2-endpoint: ${{ secrets.R2_ENDPOINT }}
-
-      - name: Set up CMake
-        uses: lukka/get-cmake@latest
-        with:
-          cmakeVersion: 4.0
-
-      - name: Setup devcmd to use cl.exe
-        uses: ilammy/msvc-dev-cmd@v1.13.0
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create build directory
         shell: bash
-        run: |
-          cmake --version
-          mkdir build
+        run: mkdir build
 
-      - name: CMake Setup on Windows
-        shell: bash
-        working-directory: build
-        run: |
-          export UseMultiToolTask=true
-          cmake .. --preset ci-msvc
+      - name: Run CMake with vcpkg.json manifest
+        uses: lukka/run-cmake@v10
+        with:
+          workflowPreset: ci-msvc
 
-      - name: Build
-        shell: bash
-        working-directory: build
-        continue-on-error: true
-        run: |
-          export UseMultiToolTask=true
-          cmake --build . --config Release
-
-      - name: Package
+      - name: List packages
         working-directory: build
         continue-on-error: true
         run: |
@@ -77,191 +58,3 @@ jobs:
             build/dist/*.zip
             build/dist/*.exe
             build/dist/*.nupkg
-
-      - name: Install from build
-        working-directory: build
-        continue-on-error: true
-        run: |
-          cmake --build . --config Release --target install
-
-      - name: Set PATH for Windows
-        shell: bash
-        continue-on-error: true
-        run: |
-          echo "/c/Program Files/srcML/bin" >> $GITHUB_PATH
-
-      - name: Run Installed srcml
-        shell: bash
-        working-directory: build
-        continue-on-error: true
-        run: |
-          EOL="\r\n"
-          SRCML_HOME="/c/Program Files/srcML/bin"
-          ls -lh "$SRCML_HOME"
-          SRCML="$SRCML_HOME/srcml.exe"
-          ls -lh "$SRCML"
-          export MSYS2_ARG_CONV_EXCL="*"
-          diff='diff -Z '
-          "$SRCML" --version
-          "$SRCML" --text="int a;" -l C++
-          touch "a.cpp"
-          "$SRCML" a.cpp
-          echo "a;" >> a.cpp
-          "$SRCML" a.cpp
-          echo "b;" >> b.cpp
-          "$SRCML" a.cpp b.cpp
-
-      - name: Create build examples directory
-        shell: bash
-        continue-on-error: true
-        run: |
-          mkdir build2
-
-      - name: Build examples
-        shell: bash
-        working-directory: build2
-        continue-on-error: true
-        run: |
-          cmake "/c/Program Files/srcML/share/srcml/examples/libsrcml" -DsrcML_DIR="C:/Program Files/srcML/cmake" -G Ninja
-          ninja
-
-      - name: Run examples in PowerShell (see loader errors)
-        shell: pwsh
-        working-directory: build2
-        continue-on-error: true
-        run: |
-          Get-ChildItem *.exe
-          foreach ($e in Get-ChildItem *.exe) {
-            Write-Host "== $($e.Name) =="
-            & .\${e.Name}
-            if ($LASTEXITCODE) { Write-Host "rc=$LASTEXITCODE" }
-          }
-
-      - name: Run examples
-        shell: bash
-        working-directory: build2
-        continue-on-error: true
-        run: |
-          ls *.exe
-          ./srcml_copy_archive.exe || echo $?
-          ./srcml_create_archive_fd.exe || echo $?
-          ./srcml_create_archive_file.exe || echo $?
-          ./srcml_create_archive_filename.exe || echo $?
-          ./srcml_create_archive_full.exe || echo $?
-          ./srcml_direct_language.exe || echo $?
-          ./srcml_direct_language_list.exe || echo $?
-          ./srcml_direct_language_xml.exe || echo $?
-          ./srcml_direct_src2srcml.exe || echo $?
-          ./srcml_direct_srcml2src.exe || echo $?
-          ./srcml_list.exe || echo $?
-          ./srcml_read_archive_fd.exe || echo $?
-          ./srcml_read_archive_file.exe || echo $?
-          ./srcml_read_archive_filename.exe || echo $?
-          ./srcml_read_archive_full.exe || echo $?
-          ./srcml_read_archive_memory.exe || echo $?
-          ./srcml_relaxng.exe || echo $?
-          ./srcml_sort_archive.exe || echo $?
-          ./srcml_split_archive.exe || echo $?
-          ./srcml_transform.exe || echo $?
-          ./srcml_xpath.exe || echo $?
-          ./srcml_xslt.exe || echo $?
-
-  test-installer:
-    needs: build
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        installer: [msi, inno, nuget]
-
-    steps:
-
-      # Download the installer artifact
-      - name: Download installer
-        uses: actions/download-artifact@v4
-        with:
-          name: "Windows Packages"
-
-      - name: Install package Wix msi
-        if: ${{ matrix.installer == 'msi' }}
-        run: |
-          msiexec /i srcml-1.1.0-windows-x86_64.msi /quiet /norestart /L*vx .\msi.log
-      - uses: actions/upload-artifact@v4
-        with:
-          name: msi.windows-latest.log
-          path: msi.log
-
-      - name: Install package Inno Setup
-        if: ${{ matrix.installer == 'inno' }}
-        run: |
-          dir
-          D:\a\srcML\srcML\srcml-1.1.0-windows-x86_64.exe /VERYSILENT /LOG="$GITHUB_WORKSPACE/inno.log"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: inno.windows-latest.log
-          path: inno.log
-
-      - name: Install package Nuget
-        if: ${{ matrix.installer == 'nuget' }}
-        run: |
-          mkdir LocalNuGetFeed
-          nuget add srcml.1.1.0.nupkg -Source LocalNuGetFeed -Verbosity detailed -NonInteractive
-          nuget install srcml -Source D:\a\srcML\srcML\LocalNuGetFeed -OutputDirectory "C:\Program Files" -Verbosity detailed -NonInteractive
-          mv "C:\Program Files\srcml.1.1.0" "C:\Program Files\srcML"
-
-      - name: Set PATH for Windows
-        shell: bash
-        continue-on-error: true
-        run: |
-          echo "C:\\Program Files\\srcML\\bin" >> "$GITHUB_PATH"
-          ls -lh "/c/Program Files/srcML/bin"
-
-      - name: Run Installed srcml
-        shell: bash
-        continue-on-error: true
-        run: |
-          srcml --help
-          srcml --text="a;" -l C++
-
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Setup msys2 with additional client-test packages for Windows
-        uses: msys2/setup-msys2@v2
-        continue-on-error: true
-        with:
-          install: >-
-            zip
-            cpio
-            diffutils
-            util-linux
-            cmake
-            libxml2
-
-      - name: Create build directory
-        shell: bash
-        run: |
-          mkdir build
-
-      - name: Build
-        shell: bash
-        working-directory: build
-        continue-on-error: true
-        run: |
-          export UseMultiToolTask=true
-          cmake ../test -DSRCML_TEST_INSTALLED=ON -G Ninja
-
-      - name: Test client
-        uses: ./.github/actions/test-client
-        with:
-          prefix: "Windows ${{ matrix.installer }}"
-
-      - name: Test libsrcml
-        uses: ./.github/actions/test-libsrcml
-        with:
-          prefix: "Windows ${{ matrix.installer }}"
-
-      - name: Test parser
-        uses: ./.github/actions/test-parser
-        with:
-          prefix: "Windows ${{ matrix.installer }}"

--- a/.github/workflows/CacheWindowsDependencies.yml
+++ b/.github/workflows/CacheWindowsDependencies.yml
@@ -6,45 +6,31 @@ on:
   schedule:
     - cron: '43 12 * * *'
 
+permissions:
+  packages: write
+
 jobs:
-  build:
-    runs-on: windows-latest
-    timeout-minutes: 30
+  job:
+    name: ${{ matrix.os }}-${{ github.workflow }}
+    runs-on: ${{ matrix.os }}
     environment: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        triplet: [x64-windows]
+
     steps:
+      - uses: actions/checkout@v4
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Setup Windows
-        uses: microsoft/setup-msbuild@v1.3.1
+      - uses: lukka/get-cmake@latest
 
       - name: Setup vcpkg
         uses: ./.github/actions/vcpkg
         with:
-          vcpkg-ref: e140b1fde236eb682b0d47f905e65008a191800f
-          r2-access-key: ${{ secrets.R2_ACCESS_KEY }}
-          r2-secret-key: ${{ secrets.R2_SECRET_KEY }}
-          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
-          r2-endpoint: ${{ secrets.R2_ENDPOINT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up CMake
-        uses: lukka/get-cmake@latest
+      - name: Run CMake
+        uses: lukka/run-cmake@v10
         with:
-          cmakeVersion: 4.0
-
-      - name: Setup devcmd to use cl.exe
-        uses: ilammy/msvc-dev-cmd@v1.13.0
-
-      - name: Create build directory
-        shell: bash
-        run: |
-          cmake --version
-          mkdir build
-
-      - name: CMake Setup on Windows
-        shell: bash
-        working-directory: build
-        run: |
-          export UseMultiToolTask=true
-          cmake .. --preset ci-msvc
+          configurePreset: ci-msvc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@
 # The master CMake project file for srcML
 
 if(DEFINED ENV{VCPKG_ROOT} OR DEFINED CMAKE_TOOLCHAIN_FILE)
+    message(STATUS "Building with vcpkg")
     set(VCPKG_BUILD_TYPE "release")
+    include("$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
 endif()
 
 cmake_minimum_required(VERSION 3.28)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # 
 # The master CMake project file for srcML
 
-if(DEFINED ENV{VCPKG_ROOT} OR DEFINED CMAKE_TOOLCHAIN_FILE)
+if(DEFINED ENV{VCPKG_ROOT})
     message(STATUS "Building with vcpkg")
     set(VCPKG_BUILD_TYPE "release")
     include("$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")

--- a/presets/CMakeMSVCPresets.json
+++ b/presets/CMakeMSVCPresets.json
@@ -10,6 +10,7 @@
       "description": "Default build options for MSVC",
       "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" },
       "toolchainFile": "toolchain-msvc.cmake",
+      "inherits": ["ci-base", "ci-subdirectory-build"],
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "cl",
         "CMAKE_C_COMPILER": "cl",
@@ -22,15 +23,17 @@
         "SRCML_LIBSRCML_SHARED_LINK_FLAGS_RELEASE": "/DEBUG /OPT:REF /OPT:ICF",
         "SRCML_LIBSRCML_STATIC_LINK_FLAGS_RELEASE": "/LTCG:OFF",
         "SRCML_CLIENT_COMPILE_FLAGS": "/wd4355;/wd5204",
-        "SRCML_CLIENT_LINK_FLAGS": ""
+        "SRCML_CLIENT_LINK_FLAGS": "",
+        "VCPKG_FEATURE_FLAGS": "manifests,binarycaching,-compilertracking",
+        "VCPKG_INSTALL_OPTIONS": "--x-abi-tools-use-exact-versions"
       }
     }
   ],
   "buildPresets" : [
     {
       "name": "ci-msvc-only",
-      "displayName": "Ubuntu only",
-      "description": "Restrict to Ubuntu",
+      "displayName": "MSVC only",
+      "description": "Restrict to MSVC",
       "hidden": true,
       "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" },
       "configurePreset": "ci-msvc"

--- a/presets/CMakeUbuntuPresets.json
+++ b/presets/CMakeUbuntuPresets.json
@@ -22,6 +22,22 @@
       "displayName": "Ubuntu Release",
       "description": "Default build options for Ubuntu release",
       "inherits": ["ci-base", "ci-ubuntu-only", "ci-gcc", "ci-sibling-build"]
+    },
+    {
+      "name": "ci-ubuntu-wasm",
+      "displayName": "Ubuntu Release",
+      "description": "Default build options for Ubuntu release",
+      "inherits": ["ci-base", "ci-ubuntu-only", "ci-gcc", "ci-subdirectory-build"],
+      "cacheVariables": {
+        "VCPKG_FEATURE_FLAGS": "manifests,binarycaching,-compilertracking",
+        "VCPKG_INSTALL_OPTIONS": "--x-abi-tools-use-exact-versions",
+        "BUILD_SHARED_LIBS": "OFF",
+        "SRCML_BUILD_CLIENT": "OFF",
+        "SRCML_BUILD_TESTS": "OFF",
+        "BUILD_LIBSRCML_TESTS": "OFF",
+        "BUILD_PARSER_TESTS": "OFF",
+        "VCPKG_TARGET_TRIPLET": "wasm32-emscripten"
+      }
     }
   ],
   "buildPresets" : [
@@ -93,6 +109,14 @@
         { "type": "build",     "name": "ci-test-client-ubuntu" },
         { "type": "build",     "name": "ci-test-libsrcml-ubuntu" },
         { "type": "build",     "name": "ci-test-parser-ubuntu" }
+      ]
+    },
+    {
+      "name": "ci-ubuntu-wasm",
+      "steps": [
+        { "type": "configure", "name": "ci-ubuntu" },
+        { "type": "build",     "name": "ci-ubuntu" },
+        { "type": "package",   "name": "ci-ubuntu" }
       ]
     }
   ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,13 +16,15 @@ include(InstallRequiredSystemLibraries)
 # Build options
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(BUILD_LIBSRCML "Build (and potentially install) libsrcml" ON)
+option(BUILD_CLIENT "Build srcML client" ON)
 
-# Exeternally defined compile and link options
+# Externally defined compile and link options
 add_compile_options(${SRCML_GLOBAL_COMPILE_OPTIONS})
 add_link_options("${SRCML_GLOBAL_LINK_OPTIONS}")
 
-# if(BUILD_LIBSRCML)
-    add_subdirectory(parser)
-    add_subdirectory(libsrcml)
-# endif()
-add_subdirectory(client)
+add_subdirectory(parser)
+add_subdirectory(libsrcml)
+
+if(BUILD_CLIENT)
+    add_subdirectory(client)
+endif()

--- a/src/libsrcml/CMakeLists.txt
+++ b/src/libsrcml/CMakeLists.txt
@@ -37,6 +37,7 @@ endif()
 # Merge all object code into one object file to build static library from
 # Use this to build static library as it 1) hides filenames 2) hides symbols that are internal only
 set(LIBSRCML_OBJECTS $<TARGET_OBJECTS:libsrcml> $<TARGET_OBJECTS:parser> $<TARGET_OBJECTS:antlr>)
+
 if(NOT MSVC)
     set(LIBSRCML_OBJECT_FILENAME libsrcml${CMAKE_CXX_OUTPUT_EXTENSION})
 
@@ -51,6 +52,51 @@ if(NOT MSVC)
             DEPENDS libsrcml parser antlr
             COMMAND_EXPAND_LISTS
         )
+
+        # Building srcml js/wasm
+        add_custom_target(libsrcml_js)
+        set_target_properties(libsrcml_js PROPERTIES
+                ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+        )
+        add_dependencies(libsrcml_js libsrcml_static)
+
+        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+            set(WASM_OPTIONS "-O0")
+        else()
+            set(WASM_OPTIONS "-O3")
+        endif()
+
+        option(EMSCRIPTEN_TARGET "Target 'NODE' or 'BROWSER'" BROWSER)
+        if (EMSCRIPTEN_TARGET STREQUAL "NODE")
+            set(WASM_OPTIONS ${WASM_OPTIONS} "-sNODERAWFS=1 sENVIRONMENT=worker,node")
+        else()
+            set(WASM_OPTIONS ${WASM_OPTIONS} "-sENVIRONMENT=worker,web")
+        endif()
+
+        # TODO: Replace with v1.1.0 curated exports, for now export everything
+        set(EXPORTS "")
+        file(READ "export_list" FILE_CONTENT)
+        string(REGEX REPLACE "\n" ";" FILE_LINES "${FILE_CONTENT}")
+        foreach(line ${FILE_LINES})
+            string(APPEND EXPORTS "${line},")
+        endforeach()
+        string(REGEX REPLACE ",$" "" EXPORTS "${EXPORTS}")
+
+        # TODO: Link against required libraries only
+        file(GLOB VCPKG_SRCML_DEPENDENCIES "${CMAKE_SOURCE_DIR}/build/vcpkg_installed/wasm32-emscripten/lib/*.a")
+        add_custom_command(
+                TARGET libsrcml_js
+                POST_BUILD
+                COMMAND emcc "${CMAKE_BINARY_DIR}/bin/libsrcml.a" ${VCPKG_SRCML_DEPENDENCIES}
+                -o "${CMAKE_BINARY_DIR}/bin/libsrcml-${PROJECT_VERSION}.js"
+                -sEXPORTED_FUNCTIONS=${EXPORTS},_malloc,_free
+                -sEXPORTED_RUNTIME_METHODS=ccall,cwrap,setValue,getValue,UTF8ToString,stringToUTF8
+                -fexceptions -sALLOW_MEMORY_GROWTH -pthread -sPTHREAD_POOL_SIZE=2
+                -sMODULARIZE=1 -sEXPORT_ES6=1 ${WASM_OPTIONS}
+                COMMAND_EXPAND_LISTS
+                VERBATIM
+        )
+
     elseif(${NUM_OSX_ARCHITECTURES} EQUAL 2)
         # Generate a single-object macOS static library for mulitple architectures
         add_custom_command(
@@ -81,6 +127,12 @@ if(NOT MSVC)
 
     set(LIBSRCML_OBJECTS ${LIBSRCML_OBJECT_FILENAME})
 endif()
+
+if(DEFINED SRCML_LIBSRCML_COMPILE_FLAGS)
+    target_compile_options(libsrcml PRIVATE ${SRCML_LIBSRCML_COMPILE_FLAGS})
+endif()
+
+# Building static library for srcML
 add_library(libsrcml_static STATIC ${LIBSRCML_OBJECTS})
 set_target_properties(libsrcml_static PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
@@ -91,66 +143,71 @@ set_target_properties(libsrcml_static PROPERTIES
     VISIBILITY_INLINES_HIDDEN ON
 )
 target_include_directories(libsrcml_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
 target_link_libraries(libsrcml_static PRIVATE LibXml2::LibXml2 Iconv::Iconv LibXslt::LibXslt LibXslt::LibExslt)
 
-# Building shared library for srcML
-add_library(libsrcml_shared SHARED)
-set_target_properties(libsrcml_shared PROPERTIES POSITION_INDEPENDENT_CODE ON)
-set_target_properties(libsrcml_shared PROPERTIES
-
-    # All of these are not needed on Unix, but are needed on Windows
-    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-
-    VERSION "${PROJECT_VERSION}"
-    SOVERSION "${PROJECT_VERSION_MAJOR}"
-
-    CXX_VISIBILITY_PRESET hidden
-    C_VISIBILITY_PRESET hidden
-    VISIBILITY_INLINES_HIDDEN ON
-)
-target_link_libraries(libsrcml_shared PRIVATE libsrcml parser antlr)
-target_include_directories(libsrcml_shared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-
 if(WIN32)
-    set(SRCML_LIBSRCML_SHARED_OUTPUT_NAME "libsrcml")
     set(SRCML_LIBSRCML_STATIC_OUTPUT_NAME "libsrcml_static")
 else()
-    set(SRCML_LIBSRCML_SHARED_OUTPUT_NAME "srcml")
     set(SRCML_LIBSRCML_STATIC_OUTPUT_NAME "srcml")
 endif()
-set_target_properties(libsrcml_shared PROPERTIES OUTPUT_NAME "${SRCML_LIBSRCML_SHARED_OUTPUT_NAME}")
 set_target_properties(libsrcml_static PROPERTIES OUTPUT_NAME "${SRCML_LIBSRCML_STATIC_OUTPUT_NAME}")
-
-if(DEFINED SRCML_LIBSRCML_COMPILE_FLAGS)
-    target_compile_options(libsrcml PRIVATE ${SRCML_LIBSRCML_COMPILE_FLAGS})
-endif()
-
-if(DEFINED SRCML_LIBSRCML_SHARED_LINK_FLAGS_RELEASE)
-    set_target_properties(libsrcml_shared PROPERTIES LINK_FLAGS_RELEASE "${SRCML_LIBSRCML_SHARED_LINK_FLAGS_RELEASE}")
-endif()
 
 if(DEFINED SRCML_LIBSRCML_STATIC_LINK_FLAGS_RELEASE)
     set_target_properties(libsrcml_static PROPERTIES LINK_FLAGS_RELEASE "${SRCML_LIBSRCML_STATIC_LINK_FLAGS_RELEASE}")
 endif()
 
-# Apply preset linker flags for libsrcml
-set_target_properties(libsrcml_shared libsrcml_static PROPERTIES LINK_FLAGS "${SRCML_LIBSRCML_LINK_FLAGS}")
+set_target_properties(libsrcml_static PROPERTIES LINK_FLAGS "${SRCML_LIBSRCML_LINK_FLAGS}")
 
-# PreCompiled Headers configuration of libsrcml
+# PreCompiled Headers configuration of libsrcml static
 if (SRCML_LIBSRCML_PCH)
-    target_precompile_headers(libsrcml_shared PRIVATE "${SRCML_LIBSRCML_PCH}")
     target_precompile_headers(libsrcml_static PRIVATE "${SRCML_LIBSRCML_PCH}")
 endif()
 
-# which types of libraries
-if(WIN32)
-    # libsrcml shared
-    install(TARGETS libsrcml_shared EXPORT libsrcml_shared_Targets RUNTIME COMPONENT SRCML ARCHIVE COMPONENT DEVLIBS)
-    install(FILES $<TARGET_PDB_FILE:libsrcml_shared> DESTINATION bin OPTIONAL COMPONENT DEVLIBS)
-else()
-    install(TARGETS libsrcml_shared EXPORT libsrcml_shared_Targets LIBRARY COMPONENT SRCML NAMELINK_COMPONENT DEVLIBS)
+# Building shared library for srcML
+if(BUILD_SHARED_LIBS)
+    add_library(libsrcml_shared SHARED)
+    set_target_properties(libsrcml_shared PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    set_target_properties(libsrcml_shared PROPERTIES
+        # All of these are not needed on Unix, but are needed on Windows
+        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+
+        VERSION "${PROJECT_VERSION}"
+        SOVERSION "${PROJECT_VERSION_MAJOR}"
+
+        CXX_VISIBILITY_PRESET hidden
+        C_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON
+    )
+    target_include_directories(libsrcml_shared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+    target_link_libraries(libsrcml_shared PRIVATE libsrcml parser antlr)
+
+    if(WIN32)
+        set(SRCML_LIBSRCML_SHARED_OUTPUT_NAME "libsrcml")
+    else()
+        set(SRCML_LIBSRCML_SHARED_OUTPUT_NAME "srcml")
+    endif()
+    set_target_properties(libsrcml_shared PROPERTIES OUTPUT_NAME "${SRCML_LIBSRCML_SHARED_OUTPUT_NAME}")
+
+    if(DEFINED SRCML_LIBSRCML_SHARED_LINK_FLAGS_RELEASE)
+        set_target_properties(libsrcml_shared PROPERTIES LINK_FLAGS_RELEASE "${SRCML_LIBSRCML_SHARED_LINK_FLAGS_RELEASE}")
+    endif()
+
+    set_target_properties(libsrcml_shared PROPERTIES LINK_FLAGS "${SRCML_LIBSRCML_LINK_FLAGS}")
+
+    if (SRCML_LIBSRCML_PCH)
+        target_precompile_headers(libsrcml_shared PRIVATE "${SRCML_LIBSRCML_PCH}")
+    endif()
+
+    if(WIN32)
+        install(TARGETS libsrcml_shared EXPORT libsrcml_shared_Targets RUNTIME COMPONENT SRCML ARCHIVE COMPONENT DEVLIBS)
+        install(FILES $<TARGET_PDB_FILE:libsrcml_shared> DESTINATION bin OPTIONAL COMPONENT DEVLIBS)
+    else()
+        install(TARGETS libsrcml_shared EXPORT libsrcml_shared_Targets LIBRARY COMPONENT SRCML NAMELINK_COMPONENT DEVLIBS)
+    endif()
+
 endif()
 
 option(SRCML_INSTALL_CMAKE_CONFIG "Install the cmake configuration for external projects" ON)
@@ -161,11 +218,13 @@ include(CMakePackageConfigHelpers)
 # directory to put the config files
 set(CONFIG_FILE_DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/srcml")
 
-install(EXPORT libsrcml_shared_Targets
-        DESTINATION "${CONFIG_FILE_DESTINATION}"
-        NAMESPACE srcML::
-        FILE srcML-shared-targets.cmake
-        COMPONENT DEVLIBS)
+if (BUILD_SHARED_LIBS)
+    install(EXPORT libsrcml_shared_Targets
+            DESTINATION "${CONFIG_FILE_DESTINATION}"
+            NAMESPACE srcML::
+            FILE srcML-shared-targets.cmake
+            COMPONENT DEVLIBS)
+endif()
 
 configure_package_config_file(
     ${CMAKE_SOURCE_DIR}/srcMLConfig.cmake.in ${CMAKE_BINARY_DIR}/srcMLConfig.cmake


### PR DESCRIPTION
Dependent on some changes in #2312 

* Adds a wasm cmake preset and workflow under ubuntu
* Adds a cmake option BUILD_CLIENT to toggle client build
* Adds a custom target to cmake when built under emscripten
* Reordered libsrcml cmake into static and shared sections for readability
* Github workflow to build and upload wasm artifacts 