### PR TITLE
Fix empty init markup in for-loops for non-Python languages

### DIFF
--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -3298,8 +3298,13 @@ control_initialization_action[] { ENTRY_DEBUG } :
 
             bool in_if_mode = inPrevMode(MODE_IF);
 
-            // setup a mode for initialization that will end with a ";"
-            startNewMode(MODE_EXPRESSION | MODE_EXPECT | MODE_STATEMENT | MODE_LIST);
+            if (LA(1) == RPAREN) {
+                // an empty control initialization should not contain an expression
+                startNewMode(MODE_INIT);
+            } else {
+                // setup a mode for initialization that will end with a ";"
+                startNewMode(MODE_EXPRESSION | MODE_EXPECT | MODE_STATEMENT | MODE_LIST);
+            }
 
             if (!in_if_mode) {
                 startElement(SCONTROL_INITIALIZATION);

--- a/test/parser/testsuite/for_base.cpp.xml
+++ b/test/parser/testsuite/for_base.cpp.xml
@@ -22,8 +22,18 @@
 </unit>
 
 <unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
+<for>for <control>(<init/>)</control><block type="pseudo"><block_content>
+<empty_stmt>;</empty_stmt></block_content></block></for>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
 <for>for <control>(<init>;</init><condition>;</condition><incr/>)</control><block type="pseudo"><block_content>
 <empty_stmt>;</empty_stmt></block_content></block></for>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
+<for>for <control>(<init/>)</control>
+<block>{<block_content/>}</block></for>
 </unit>
 
 <unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">


### PR DESCRIPTION
Adjusted initialization markup in for-loops for non-Python languages to help `srcQL`.

Before:
```xml
<for>for<control>(<init><expr/></init>)</control> <block>{<block_content/>}</block></for>
```

After:
```xml
<for>for<control>(<init/>)</control> <block>{<block_content/>}</block></for>
```