### PR TITLE
Add support for invalid keyword call markup for srcQL

### DIFF
--- a/src/parser/srcMLParser.g
+++ b/src/parser/srcMLParser.g
@@ -2817,10 +2817,6 @@ perform_call_check[CALL_TYPE& type, bool& isempty, int& call_count, int secondto
                         && !inTransparentMode(MODE_INTERNAL_END_CURLY)
                         && postcalltoken == RCURLY
                     )
-                    || (
-                        postnametoken != 1
-                        && postcalltoken == 1 /* EOF ? */
-                    )
                     || postcalltoken == TEMPLATE
                     || postcalltoken == INLINE
                     || postcalltoken == PUBLIC

--- a/test/parser/testsuite/CMakeLists.txt
+++ b/test/parser/testsuite/CMakeLists.txt
@@ -223,6 +223,11 @@ foreach(GENURL IN ITEMS ${TESTFILES})
             continue()
         endif()
 
+        # skip generating any test variation for files containing invalid code (e.g., for srcQL purposes)
+        if(URL STREQUAL "keyword_call_cpp" OR URL STREQUAL "keyword_call_m" OR URL STREQUAL "keyword_call_cs")
+            continue()
+        endif()
+
         add_custom_command(
             COMMAND ${SRCML_EXE} --output-srcml --xslt ${XSLT_DIR}/insert${VARIATION}.xsl --url=${URL}.${VARIATION} ${GENURL}
                      -o ${URL}.${VARIATION}.${LANGEXT}.xml
@@ -234,15 +239,18 @@ foreach(GENURL IN ITEMS ${TESTFILES})
         list(APPEND CONTEXT_FILES ${URL}.${VARIATION}.${LANGEXT}.xml)
     endforeach()
 
-    # all is generated separately because it does not use an XSLT transformation
-    add_custom_command(
-        COMMAND ${SRCML_EXE} --cat --url=${URL}.all ${GENURL} -o ${URL}.all.${LANGEXT}.xml
-        COMMENT "Generating parser testfile ${URL}.all.${LANGEXT}.xml from ${GENURL}"
-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${GENURL}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        OUTPUT ${URL}.all.${LANGEXT}.xml
-    )
-    list(APPEND CONTEXT_FILES ${URL}.all.${LANGEXT}.xml)
+    # skip generating a test "all" file for files containing invalid code (e.g., for srcQL purposes)
+    if(NOT (URL STREQUAL "keyword_call_cpp") AND NOT (URL STREQUAL "keyword_call_m") AND NOT (URL STREQUAL "keyword_call_cs"))
+        # all is generated separately because it does not use an XSLT transformation
+        add_custom_command(
+            COMMAND ${SRCML_EXE} --cat --url=${URL}.all ${GENURL} -o ${URL}.all.${LANGEXT}.xml
+            COMMENT "Generating parser testfile ${URL}.all.${LANGEXT}.xml from ${GENURL}"
+            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${GENURL}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            OUTPUT ${URL}.all.${LANGEXT}.xml
+        )
+        list(APPEND CONTEXT_FILES ${URL}.all.${LANGEXT}.xml)
+    endif()
 
 endforeach()
 

--- a/test/parser/testsuite/keyword_call_cpp.cpp.xml
+++ b/test/parser/testsuite/keyword_call_cpp.cpp.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<unit xmlns="http://www.srcML.org/srcML/src" revision="1.0.0" language="C++" url="keyword_call_cpp">
+
+<!-- Invalid syntax on its own, but possible in srcQL -->
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
+<expr><sizeof>sizeof<argument_list>()</argument_list></sizeof></expr>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
+<expr><alignof>alignof<argument_list>()</argument_list></alignof></expr>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
+<expr><typeid>typeid<argument_list>()</argument_list></typeid></expr>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
+<expr><cast type="const">const_cast<argument_list>()</argument_list></cast></expr>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
+<expr><cast type="dynamic">dynamic_cast<argument_list>()</argument_list></cast></expr>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
+<expr><cast type="reinterpret">reinterpret_cast<argument_list>()</argument_list></cast></expr>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
+<expr><cast type="static">static_cast<argument_list>()</argument_list></cast></expr>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C++">
+<expr><decltype>decltype<argument_list>()</argument_list></decltype></expr>
+</unit>
+
+</unit>

--- a/test/parser/testsuite/keyword_call_cs.cs.xml
+++ b/test/parser/testsuite/keyword_call_cs.cs.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<unit xmlns="http://www.srcML.org/srcML/src" revision="1.0.0" language="C#" url="call" filename="keyword_call_cs">
+
+<!-- Invalid syntax on its own, but possible in srcQL -->
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C#">
+<expr><typeof>typeof<argument_list>()</argument_list></typeof></expr>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C#">
+<expr><default>default<argument_list>()</argument_list></default></expr>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C#">
+<expr><checked>checked<argument_list>()</argument_list></checked></expr>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="C#">
+<expr><unchecked>unchecked<argument_list>()</argument_list></unchecked></expr>
+</unit>
+
+</unit>

--- a/test/parser/testsuite/keyword_call_m.m.xml
+++ b/test/parser/testsuite/keyword_call_m.m.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<unit xmlns="http://www.srcML.org/srcML/src" revision="1.0.0" language="Objective-C" url="call" filename="keyword_call_m">
+
+<!-- Invalid syntax on its own, but possible in srcQL -->
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="Objective-C">
+<expr><encode>@encode<argument_list>()</argument_list></encode></expr>
+</unit>
+
+<unit xmlns:cpp="http://www.srcML.org/srcML/cpp" revision="1.0.0" language="Objective-C">
+<expr><selector>@selector<argument_list>()</argument_list></selector></expr>
+</unit>
+
+</unit>

--- a/test/parser/testsuite/suite.txt
+++ b/test/parser/testsuite/suite.txt
@@ -342,3 +342,8 @@ LANGUAGE_TRANSFORM throw_base_m.m.xml throw_base.cpp.xml throw keyword2mkeyword.
 LANGUAGE_TRANSFORM dynamic_m.m.xml synthesize_m.m.xml dynamic synthesize2dynamic.xsl
 
 LANGUAGE_TRANSFORM return.cpp.xml return_base.cpp.xml return insertexpr.xsl expr_filename=\"${CMAKE_CURRENT_BINARY_DIR}/expression.cpp.xml\"
+
+# Invalid syntax, but can appear in srcQL
+LANGUAGE_CXX keyword_call_cpp
+LANGUAGE_OBJECTIVE_C keyword_call_m
+LANGUAGE_CSHARP keyword_call_cs


### PR DESCRIPTION
Adds support for call-like syntax without semicolons to work for the following tokens:
```c++
// C++
SIZEOF | ALIGNOF | TYPEID | CONST_CAST | DYNAMIC_CAST |
REINTERPRET_CAST | STATIC_CAST | DECLTYPE |

// Objective-C
ENCODE | SELECTOR |

// C#
TYPEOF | DEFAULT | CHECKED | UNCHECKED
```
Therefore, something like `sizeof()` will be marked properly even though it is normally invalid. This is helpful for certain `srcQL` queries.