### PR TITLE
Multi lang parser test

### DIFF
--- a/src/client/ParserTest.cpp
+++ b/src/client/ParserTest.cpp
@@ -28,16 +28,20 @@ void ParserTest::entry(const ParseRequest* request, srcml_archive* archive, srcm
     if (request->url)
         url = *request->url;
 
-    if (previous_filename.empty() || (request->parsertest_filename != previous_filename)) {
+    const char* language = srcml_unit_get_language(unit);
+    if (!language) 
+        return;
 
+    bool new_archive = previous_filename.empty() || (request->parsertest_filename != previous_filename);
+
+    if (new_archive) {
         previous_filename = request->parsertest_filename;
         count = 0;
+        unit_language.clear();
+    }
 
-        if (!srcml_unit_get_language(unit))
-            return;
-
-        unit_language = srcml_unit_get_language(unit);
-
+    if (unit_language != language) {
+        unit_language = language;
         std::ostringstream sout;
         sout << '\n' << std::setw(FIELD_WIDTH_LANGUAGE) << std::left << unit_language;
         sout << std::setw(FIELD_WIDTH_URL) << std::left << url;

--- a/src/client/ParserTest.cpp
+++ b/src/client/ParserTest.cpp
@@ -123,19 +123,19 @@ void ParserTest::entry(const ParseRequest* request, srcml_archive* archive, srcm
             // find where the strings are different at the end
             const auto endoff = std::mismatch(sxml.rbegin(), sxml.rend(), ssout.rbegin());
 
-            // backup to right before the previous newline
-            while (off.first != sxml.begin() && *off.first != '\n') {
-                off.first = std::prev(off.first);
-                off.second = std::prev(off.second);
+            auto sxml_cut  = endoff.first.base();
+            auto ssout_cut = endoff.second.base();
+            while (sxml_cut != sxml.end() && *sxml_cut != '\n') {
+                sxml_cut  = std::next(sxml_cut);
+                ssout_cut = std::next(ssout_cut);
             }
-            if (*off.first == '\n') {
-                off.first = std::next(off.first);
-                off.second = std::next(off.second);
+            if (sxml_cut != sxml.end()) {
+                sxml_cut  = std::next(sxml_cut);
+                ssout_cut = std::next(ssout_cut);
             }
 
-            // remove the common end of the strings
-            sxml.resize(sxml.size() - std::distance(sxml.rbegin(), endoff.first));
-            ssout.resize(ssout.size() - std::distance(ssout.rbegin(), endoff.second));
+            sxml.erase(sxml_cut, sxml.end());
+            ssout.erase(ssout_cut, ssout.end());
         }
 
         // record for the error report

--- a/test/client/testsuite/archive.sh
+++ b/test/client/testsuite/archive.sh
@@ -38,8 +38,22 @@ defineXML nestedfile <<- 'STDOUT'
 	</unit>
 STDOUT
 
+defineXML nestedfilemultilanguage <<- 'STDOUT'
+	<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+	<unit xmlns="http://www.srcML.org/srcML/src" revision="REVISION">
+
+	<unit revision="REVISION" language="C++" filename="sub/a.cpp" hash="a301d91aac4aa1ab4e69cbc59cde4b4fff32f2b8"><expr_stmt><expr><name>a</name></expr>;</expr_stmt></unit>
+
+	<unit revision="REVISION" language="C++" filename="sub/b.cpp" hash="9a1e1d3d0e27715d29bcfbf72b891b3ece985b36"><expr_stmt><expr><name>b</name></expr>;</expr_stmt></unit>
+
+	<unit revision="REVISION" language="Python" filename="sub/c.py" hash="9db33fa0cd63d5bcc994a2d10aee7aa1c6cf5234"><expr_stmt><expr><name>c</name> <operator>=</operator> <literal type="number">1</literal></expr></expr_stmt></unit>
+
+	</unit>
+STDOUT
+
 createfile sub/a.cpp "a;"
 createfile sub/b.cpp "b;"
+createfile sub/c.py "c = 1"
 
 # test that two files will output in an archive by default
 srcml sub/a.cpp sub/b.cpp
@@ -62,6 +76,26 @@ check sub/ab.cpp.xml "$nestedfile"
 
 srcml -o sub/ab.cpp.xml sub/a.cpp sub/b.cpp
 check sub/ab.cpp.xml "$nestedfile"
+
+# Test archive with multiple languages
+
+srcml sub/a.cpp sub/b.cpp sub/c.py
+check "$nestedfilemultilanguage"
+
+srcml sub/a.cpp sub/b.cpp sub/c.py
+check "$nestedfilemultilanguage"
+
+srcml sub/a.cpp sub/b.cpp sub/c.py -o sub/abc.xml
+check sub/abc.xml "$nestedfilemultilanguage"
+
+srcml sub/a.cpp sub/b.cpp sub/c.py -o sub/abc.xml
+check sub/abc.xml "$nestedfilemultilanguage"
+
+srcml -o sub/abc.xml sub/a.cpp sub/b.cpp sub/c.py
+check sub/abc.xml "$nestedfilemultilanguage"
+
+srcml -o sub/abc.xml sub/a.cpp sub/b.cpp sub/c.py
+check sub/abc.xml "$nestedfilemultilanguage"
 
 # test explicit archive flag
 srcml sub/a.cpp --archive


### PR DESCRIPTION
Archive tests for multi-language archive were a by product of sanity checking that we were marking things up correctly, but we didn't have any so keeping them.

Running the parser-test with an archive that contained multiple languages, would treat everything belonging to the first unit it found.

This changes fixes this bug and correctly categorizes the units/languages.

```
createfile sub/a.cpp "a;"
createfile sub/b.cpp "b;"
createfile sub/c.py "c = 1"
```
```
srcml --parser-test --no-color sub/abc.xml
```
Old output:
```
C++                                       1 2 3 
Errors:
Summary:
Counts: Total            0     3	   0%
        C++              0     3	   0%
```

New output:
```
C++                                       1 2 
Python                                    3 
Errors:
Summary:
Counts: Total            0     3	   0%
        C++              0     2	   0%
        Python           0     1	   0%
```


