### PR TITLE
Change RPM package file to use CMAKE_BINARY_DIR for writing post script

### DIFF
--- a/package/rpm-cpack.cmake
+++ b/package/rpm-cpack.cmake
@@ -80,9 +80,9 @@ set(CPACK_RPM_PACKAGE_LICENSE "GPL-3.0-only")
 
 # post install script for ldconfig
 # Note: Believe that newline is required
-file(WRITE ${CPACK_BINARY_DIR}/post.sh "/sbin/ldconfig\n")
-set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE   ${CPACK_BINARY_DIR}/post.sh)
-set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE ${CPACK_BINARY_DIR}/post.sh)
+file(WRITE ${CMAKE_BINARY_DIR}/post.sh "/sbin/ldconfig\n")
+set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE   ${CMAKE_BINARY_DIR}/post.sh)
+set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE ${CMAKE_BINARY_DIR}/post.sh)
 
 # CPack puts directories of installed files into the RPM
 # Since they already exist, this is a conflict with other packages


### PR DESCRIPTION
Change rpm-cmake.cpack to use CMAKE_BINARY_DIR in place of CPACK_BINARY_DIR.