### PR TITLE
issue2366

### DIFF
--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -111,16 +111,16 @@ target_compile_options(parser PRIVATE ${SRCML_PARSER_DISABLED_WARNINGS})
 #    1 optional parameter INCLUDE_GRAMMAR
 # Use with named arguments.
 #
-macro(RunAntlr OUTPUT_FILES INPUT_FILES DEPENDENCIES INCLUDE_GRAMMAR)
+function(RunAntlr OUTPUT_FILES INPUT_FILES DEPENDENCIES INCLUDE_GRAMMAR)
 
     add_custom_command(OUTPUT  ${OUTPUT_FILES}
         DEPENDS ${INPUT_FILES} ${DEPENDENCIES}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND ${ANTLR_EXE} -o \"${CMAKE_GENERATED_SOURCE_DIR}\" -glib \"${INCLUDE_GRAMMAR}\" ${INPUT_FILES}
+        COMMAND ${ANTLR_EXE} -o \"${CMAKE_GENERATED_SOURCE_DIR}\" -glib "\"${INCLUDE_GRAMMAR}\"" ${INPUT_FILES}
         COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT_FILES}
     )
 
-endmacro(RunAntlr)
+endfunction(RunAntlr)
 
 macro(lexerFiles LEXER)
     set(${LEXER}LexerOutputFiles
@@ -161,7 +161,7 @@ lexerFiles(Keyword)
 RunAntlr("${KeywordLexerOutputFiles}"
     KeywordLexer.g
     ${CMAKE_GENERATED_SOURCE_DIR}/OperatorLexer.cpp
-    "OperatorLexer.g\;TextLexer.g"
+    "OperatorLexer.g;TextLexer.g"
 )
 
 # Running ANTLR on srcMLParser.g
@@ -174,5 +174,5 @@ set(srcMLParserOutputFiles
 RunAntlr("${srcMLParserOutputFiles}"
     srcMLParser.g
     "srcMLParser.g;${CMAKE_GENERATED_SOURCE_DIR}/KeywordLexer.cpp"
-    "OperatorLexer.g\;KeywordLexer.g\;TextLexer.g"
+    "OperatorLexer.g;KeywordLexer.g;TextLexer.g"
 )

--- a/test/parser/testsuite/suite.txt
+++ b/test/parser/testsuite/suite.txt
@@ -341,7 +341,7 @@ LANGUAGE_TRANSFORM throw_m.m.xml throw.cpp.xml throw keyword2mkeyword.xsl
 LANGUAGE_TRANSFORM throw_base_m.m.xml throw_base.cpp.xml throw keyword2mkeyword.xsl
 LANGUAGE_TRANSFORM dynamic_m.m.xml synthesize_m.m.xml dynamic synthesize2dynamic.xsl
 
-LANGUAGE_TRANSFORM return.cpp.xml return_base.cpp.xml return insertexpr.xsl expr_filename=\"${CMAKE_CURRENT_BINARY_DIR}/expression.cpp.xml\"
+LANGUAGE_TRANSFORM return.cpp.xml return_base.cpp.xml return insertexpr.xsl
 
 # Invalid syntax, but can appear in srcQL
 LANGUAGE_CXX keyword_call_cpp


### PR DESCRIPTION
- **Convert CMake macro to function and fix escaped ':'**
- **Remove unused parameter causing problem with CMake**
