### PR TITLE
Fix trivial encoding detection on linux

### DIFF
--- a/src/parser/UTF8CharBuffer.cpp
+++ b/src/parser/UTF8CharBuffer.cpp
@@ -31,24 +31,6 @@ using namespace ::std::literals::string_view_literals;
 
 namespace {
 
-    // indicates if the two given encodings are basically the same,
-    // with a trivial encoding process
-    bool compatibleEncodings(const char* encoding1, const char* encoding2) {
-
-        // setup encoder between the two encodings
-        iconv_t ce = iconv_open(encoding1, encoding2);
-        if (ce == (iconv_t) -1)
-            return false;
-
-        // see if encoding is trivial
-        int trivial = false;
-#if _LIBICONV_VERSION >= 0x0108
-        iconvctl(ce, ICONV_TRIVIALP, &trivial);
-#endif
-        iconv_close(ce);
-
-        return trivial != 0;
-    }
     // the UTF-16 or UTF-32 encoding of data that has no BOM, or empty if it is neither
     // ASCII characters, which is nearly all of any source code, are stored with NUL bytes
     // for their high-order bytes, so which positions those NUL bytes fall in gives
@@ -151,9 +133,22 @@ namespace {
         return true;
     }
 
-    // some common aliases that libiconv does not accept
+    // some common aliases that need mappings for libiconv
     std::map<std::string_view, std::string_view> encodingAliases = {
+        { "UTF8", "UTF-8"},
+        { "CSUTF8", "UTF-8"},
         { "UTF16", "UTF-16"},
+        { "CSUTF16", "UTF-16"},
+        { "UTF16LE", "UTF-16LE"},
+        { "CSUTF16LE", "UTF-16LE"},
+        { "UTF16BE", "UTF-16BE"},
+        { "CSUTF16BE", "UTF-16BE"},
+        { "UTF32", "UTF-32"},
+        { "CSUTF32", "UTF-32"},
+        { "UTF32LE", "UTF-32LE"},
+        { "CSUTF32LE", "UTF-32LE"},
+        { "UTF32BE", "UTF-32BE"},
+        { "CSUTF32BE", "UTF-32BE"},
         { "UCS2", "UCS-2"},
         { "UCS4", "UCS-4"},
     };
@@ -350,11 +345,7 @@ bool UTF8CharBuffer::setEncoding(std::string_view name) {
     encoding = std::move(next);
 
     // see if this encoding to UTF-8 is trivial, if so we can use raw characters directly
-#if _LIBICONV_VERSION >= 0x0108
-    iconvctl(ic, ICONV_TRIVIALP, &trivial);
-#else
-    trivial = false;
-#endif
+    trivial = encoding == "UTF-8"sv;
 
     return true;
 }
@@ -434,7 +425,7 @@ size_t UTF8CharBuffer::readChars() {
             // no encoding specified (by user) then UTF-8, otherwise check if it is compatible with UTF-8
             if (encoding.empty()) {
                 encoding = "UTF-8";
-            } else if (encoding != "UTF-8"sv && !compatibleEncodings(encoding.data(), "UTF-8")) {
+            } else if (encoding != "UTF-8"sv) {
                 fprintf(stderr, "Warning: the encoding %s was specified, but the source code has a UTF-8 BOM\n", encoding.data());
             }
         }
@@ -447,7 +438,7 @@ size_t UTF8CharBuffer::readChars() {
             // no encoding specified (by user) then UTF-16, otherwise check if it is compatible with UTF-16
             if (encoding.empty()) {
                 encoding = "UTF-16";
-            } else if (encoding != "UTF-16"sv && !compatibleEncodings(encoding.data(), "UTF-16")) {
+            } else if (encoding != "UTF-16"sv) {
                 fprintf(stderr, "Warning: the encoding %s was specified, but the source code has a UTF-16 BOM\n", encoding.data());
             }
         }
@@ -460,7 +451,7 @@ size_t UTF8CharBuffer::readChars() {
             // no encoding specified (by user) then UTF-32, otherwise check if it is compatible with UTF-32
             if (encoding.empty()) {
                 encoding = "UTF-32";
-            } else if (encoding != "UTF-32"sv && !compatibleEncodings(encoding.data(), "UTF-32")) {
+            } else if (encoding != "UTF-32"sv) {
                 fprintf(stderr, "Warning: the encoding %s was specified, but the source code has a UTF-32 BOM\n", encoding.data());
             }
         }
@@ -541,6 +532,13 @@ size_t UTF8CharBuffer::readChars() {
             outbytesleft = cooked.size();
 
             binsize = iconv(ic, &linbuf, &inbytesleft, &loutbuf, &outbytesleft);
+        }
+
+        // an invalid sequence is an error, as only a detected encoding is a guess that
+        // the fallback above corrects, while a specified one is not
+        if (binsize == (size_t) -1 && errno == EILSEQ) {
+            fprintf(stderr, "srcml: Input is not valid '%s'\n\n", encoding.data());
+            return 0;
         }
 
         // an incomplete multibyte sequence at the end of the data is not an error,

--- a/src/parser/UTF8CharBuffer.hpp
+++ b/src/parser/UTF8CharBuffer.hpp
@@ -142,7 +142,7 @@ private:
     iconv_t ic = nullptr;
 
     /** whether the encoding conversion is trivial (i.e., not needed) */
-    int trivial = false;
+    bool trivial = false;
 
     /** whether the encoding was detected from the data, and so may still be corrected */
     bool detected = false;

--- a/test/client/testsuite/detect_src_encoding.sh
+++ b/test/client/testsuite/detect_src_encoding.sh
@@ -139,6 +139,14 @@ createfile sub/bom.cpp '\xef\xbb\xbf// caf\xc3\xa9 na\xc3\xafve\na;\n'
 srcml sub/bom.cpp --filename "sub/a.cpp"
 check "$foutput"
 
+# an encoding is identified by a single name, so a specified encoding spelled as an
+# alias of the one the BOM indicates is that same encoding, and not a mismatch to warn about
+srcml sub/bom.cpp --src-encoding "UTF8" --filename "sub/a.cpp"
+check "$foutput"
+
+srcml sub/bom.cpp --src-encoding "utf-8" --filename "sub/a.cpp"
+check "$foutput"
+
 # UTF-16 and UTF-32 with no BOM, where the NUL bytes of the ASCII characters
 # give both the width of a character and the byte order
 # the bytes are given directly, as the point of these is where the NUL bytes fall


### PR DESCRIPTION
Since we don't use vcpkg, linux builds end up using glibc's built-in iconv which does not set `_LIBICONV_VERSION` and doesn't have `iconvctl`.

These changes should cover most cases in a platform independent way.